### PR TITLE
sqlite-pcre

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ RUBY_RPM := $(call rpm_file,ruby)
 SBT_RPM := $(call rpm_file,sbt,noarch)
 SFCGAL_RPM := $(call rpm_file,SFCGAL)
 SQLITE_RPM := $(call rpm_file,sqlite)
+SQLITE_PCRE_RPM := $(call rpm_file,sqlite-pcre)
 TBB_RPM := $(call rpm_file,tbb)
 
 # Build containers and RPMs.
@@ -122,6 +123,7 @@ RPMBUILD_RPMS := \
 	ruby \
 	sbt \
 	sqlite \
+	sqlite-pcre \
 	tbb
 
 ## General targets
@@ -175,6 +177,7 @@ distclean: .env
 	echo RPMBUILD_RUBY_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/ruby.spec) >> .env
 	echo RPMBUILD_SFCGAL_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/SFCGAL.spec) >> .env
 	echo RPMBUILD_SQLITE_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/sqlite.spec) >> .env
+	echo RPMBUILD_SQLITE_PCRE_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/sqlite-pcre.spec) >> .env
 	echo RPMBUILD_TBB_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/tbb.spec) >> .env
 
 ## Container targets
@@ -267,6 +270,9 @@ rpmbuild-sfcgal: .env $(CGAL_RPM)
 rpmbuild-sqlite: .env
 	$(DOCKER_COMPOSE) up -d rpmbuild-sqlite
 
+rpmbuild-sqlite-pcre: .env
+	$(DOCKER_COMPOSE) up -d rpmbuild-sqlite-pcre
+
 rpmbuild-tbb: .env
 	$(DOCKER_COMPOSE) up -d rpmbuild-tbb
 
@@ -303,6 +309,7 @@ rack: rpmbuild-rack $(RACK_RPM)
 ruby: rpmbuild-ruby $(RUBY_RPM)
 sbt: rpmbuild-generic $(SBT_RPM)
 sqlite: rpmbuild-sqlite $(SQLITE_RPM)
+sqlite-pcre: rpmbuild-sqlite-pcre $(SQLITE_PCRE_RPM)
 tbb: rpmbuild-tbb $(TBB_RPM)
 
 ## Build patterns

--- a/SPECS/sqlite-pcre.spec
+++ b/SPECS/sqlite-pcre.spec
@@ -28,15 +28,15 @@ libs=$(pkg-config --libs sqlite3 libpcre)
 
 
 %check
-sqlite3 >out <<EOF
+%{_bindir}/sqlite3 >out <<EOF
 .load ./pcre.so
 SELECT "asdf" REGEXP "(?i)^A";
 EOF
-grep 1 out
+%{_bindir}/grep 1 out
 
 
 %install
-%{__install} -pD -m755 pcre.so %{buildroot}%{_libdir}/sqlite/pcre.so
+%{__install} -pD -m0755 pcre.so %{buildroot}%{_libdir}/sqlite/pcre.so
 
 
 %files

--- a/SPECS/sqlite-pcre.spec
+++ b/SPECS/sqlite-pcre.spec
@@ -36,11 +36,11 @@ EOF
 
 
 %install
-%{__install} -pD -m0755 pcre.so %{buildroot}%{_libdir}/sqlite/pcre.so
+%{__install} -pD -m0755 pcre.so %{buildroot}%{_libdir}/sqlite3/pcre.so
 
 
 %files
-%{_libdir}/sqlite/pcre.so
+%{_libdir}/sqlite3/pcre.so
 
 
 %changelog

--- a/SPECS/sqlite-pcre.spec
+++ b/SPECS/sqlite-pcre.spec
@@ -1,0 +1,48 @@
+Name: sqlite-pcre
+Version: %{rpmbuild_version}
+Release: %{rpmbuild_release}%{?dist}
+
+Summary: Perl-compatible regular expression support for SQLite
+License: Public Domain
+URL: http://git.altlinux.org/people/at/packages/?p=sqlite3-pcre.git
+Source: http://archive.ubuntu.com/ubuntu/pool/universe/s/sqlite3-pcre/sqlite3-pcre_0~git20070120091816+4229ecc.orig.tar.gz
+
+BuildRequires: pcre-devel
+BuildRequires: pkgconfig
+BuildRequires: sqlite-devel
+
+
+%description
+This SQLite loadable extension enables the REGEXP operator,
+which is not implemented by default, to call PCRE routines
+for regular expression matching.
+
+
+%prep
+%autosetup -n sqlite3-pcre -p 1
+
+
+%build
+libs=$(pkg-config --libs sqlite3 libpcre)
+%{_bindir}/gcc -shared -o pcre.so %{optflags} -fPIC -W -Werror pcre.c $libs -Wl,-z,defs
+
+
+%check
+sqlite3 >out <<EOF
+.load ./pcre.so
+SELECT "asdf" REGEXP "(?i)^A";
+EOF
+grep 1 out
+
+
+%install
+%{__install} -pD -m755 pcre.so %{buildroot}%{_libdir}/sqlite/pcre.so
+
+
+%files
+%{_libdir}/sqlite/pcre.so
+
+
+%changelog
+* %(%{_bindir}/date "+%%a %%b %%d %%Y") %{rpmbuild_name} <%{rpmbuild_email}> - %{version}-%{rpmbuild_release}
+- %{version}-%{rpmbuild_release}

--- a/SPECS/sqlite-pcre.spec
+++ b/SPECS/sqlite-pcre.spec
@@ -5,7 +5,7 @@ Release: %{rpmbuild_release}%{?dist}
 Summary: Perl-compatible regular expression support for SQLite
 License: Public Domain
 URL: http://git.altlinux.org/people/at/packages/?p=sqlite3-pcre.git
-Source: http://archive.ubuntu.com/ubuntu/pool/universe/s/sqlite3-pcre/sqlite3-pcre_0~git20070120091816+4229ecc.orig.tar.gz
+Source: https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/sqlite3-pcre/0~git20070120091816+4229ecc-2/sqlite3-pcre_0~git20070120091816+4229ecc.orig.tar.gz
 
 BuildRequires: pcre-devel
 BuildRequires: pkgconfig

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,9 @@ x-rpmbuild:
     sqlite:
       image: rpmbuild-sqlite
       version: &sqlite_version '3.36.0-1'
+    sqlite-pcre:
+      image: rpmbuild-sqlite-pcre
+      version: &sqlite_pcre_version '2007.1.20-1'
     tbb:
       image: rpmbuild-tbb
       version: &tbb_version '2020.3-1'
@@ -602,6 +605,17 @@ services:
       args:
         packages: "${RPMBUILD_SQLITE_PACKAGES}"
         rpmbuild_channel: *rpmbuild_channel
+  rpmbuild-sqlite-pcre:
+    <<: *service_defaults
+    depends_on:
+      - rpmbuild-sqlite
+    build:
+      <<: *build_defaults
+      args:
+        packages: "${RPMBUILD_SQLITE_PCRE_PACKAGES}"
+        rpmbuild_channel: *rpmbuild_channel
+        sqlite_version: *sqlite_version
+      dockerfile: docker/Dockerfile.rpmbuild-proj
   rpmbuild-tbb:
     <<: *service_defaults
     depends_on:

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -350,6 +350,12 @@ and are [MIT licensed](./licenses/Fedora-LICENSE):
 * [`sqlite-3.8.0-percentile-test.patch`](../SOURCES/sqlite-3.8.0-percentile-test.patch)
 * [`sqlite-3.18.0-sync2-dirsync.patch`](../SOURCES/sqlite-3.18.0-sync2-dirsync.patch)
 
+## sqlite-pcre
+
+The `sqlite-pcre` package is derived from
+[Ubuntu's `sqlite3-pcre`](https://launchpad.net/ubuntu/+source/sqlite3-pcre/0~git20070120091816+4229ecc-2);
+its source code and spec file are considered public domain.
+
 ## TBB
 
 The `tbb` package provides Intel's [Thread Building Blocks](http://threadingbuildingblocks.org/) library.


### PR DESCRIPTION
Adds support to build a shared library implementing `REGEX` functionality with PCRE.  OSM's Taginfo, in particular, depends on this functionality.  Some notes:

* I use Ubuntu's source as upstream doesn't provide any archives.
* This piggy-back's on the `Dockerfile.rpmbuild-proj` to use the locally built SQLite RPM.
* The original source code from 2007 included a spec file from which `sqlite-pcre.spec` was derived before updating to modern standards.