### PR TITLE
SQLite FTS5 Extension

### DIFF
--- a/SPECS/sqlite.spec
+++ b/SPECS/sqlite.spec
@@ -138,6 +138,7 @@ export CFLAGS="$RPM_OPT_FLAGS $RPM_LD_FLAGS -DSQLITE_ENABLE_COLUMN_METADATA=1 \
                -DSQLITE_ENABLE_FTS3_PARENTHESIS=1 -fno-strict-aliasing"
 export TCLLIBDIR=%{tcl_sitearch}/sqlite3
 %configure --enable-all \
+           --enable-fts5 \
            --enable-threadsafe \
            --enable-threads-override-locks \
            --enable-load-extension

--- a/SPECS/sqlite.spec
+++ b/SPECS/sqlite.spec
@@ -132,17 +132,33 @@ This package contains the analysis program for %{name}.
 
 
 %build
-export CFLAGS="$RPM_OPT_FLAGS $RPM_LD_FLAGS -DSQLITE_ENABLE_COLUMN_METADATA=1 \
-               -DSQLITE_DISABLE_DIRSYNC=1 -DSQLITE_SECURE_DELETE=1 \
-               -DSQLITE_ENABLE_UNLOCK_NOTIFY=1 -DSQLITE_ENABLE_DBSTAT_VTAB=1 \
-               -DSQLITE_ENABLE_FTS3_PARENTHESIS=1 -fno-strict-aliasing"
+export CFLAGS="$RPM_OPT_FLAGS $RPM_LD_FLAGS \
+  -DSQLITE_DISABLE_DIRSYNC \
+  -DSQLITE_ENABLE_API_ARMOR \
+  -DSQLITE_ENABLE_COLUMN_METADATA \
+  -DSQLITE_ENABLE_DBSTAT_VTAB \
+  -DSQLITE_ENABLE_FTS3 \
+  -DSQLITE_ENABLE_FTS3_PARENTHESIS \
+  -DSQLITE_ENABLE_GEOPOLY \
+  -DSQLITE_ENABLE_JSON1 \
+  -DSQLITE_ENABLE_MATH_FUNCTIONS \
+  -DSQLITE_ENABLE_PREUPDATE_HOOK \
+  -DSQLITE_ENABLE_RTREE \
+  -DSQLITE_ENABLE_SESSION \
+  -DSQLITE_ENABLE_SOUNDEX \
+  -DSQLITE_ENABLE_STMTVTAB \
+  -DSQLITE_ENABLE_UNLOCK_NOTIFY \
+  -DSQLITE_LIKE_DOESNT_MATCH_BLOBS \
+  -DSQLITE_SECURE_DELETE \
+  -DSQLITE_USE_URI \
+  -Wall -fno-strict-aliasing"
 export TCLLIBDIR=%{tcl_sitearch}/sqlite3
 %configure --enable-all \
+           --enable-fts4 \
            --enable-fts5 \
            --enable-threadsafe \
            --enable-threads-override-locks \
            --enable-load-extension
-
 
 # rpath removal
 %{__sed} -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,7 @@ x-rpmbuild:
     #    - zfs_host
     sqlite:
       image: rpmbuild-sqlite
-      version: &sqlite_version '3.36.0-1'
+      version: &sqlite_version '3.36.0-2'
     tbb:
       image: rpmbuild-tbb
       version: &tbb_version '2020.3-1'


### PR DESCRIPTION
* Curiously you have to pass `--enable-fts5` explicitly for this, `--enable-all` wasn't enough :man_shrugging: 
* Went through compilation flags one by one, re-formatting and enabling some other missing features/hardening.
* Extension also explicitly required by OSM's Taginfo, see also #4.

Currently live in the stable channel as `3.36.0-2`.