### PR TITLE
Add patch to build CGAL with CGAL_DISABLE_ROUNDING_MATH_CHECK defined

### DIFF
--- a/SOURCES/cgal-rounding-math.patch
+++ b/SOURCES/cgal-rounding-math.patch
@@ -1,0 +1,13 @@
+diff -rupN --no-dereference CMakeLists.txt CMakeLists.txt
+--- CMakeLists.txt	2021-08-12 12:35:38.273409524 -0500
++++ CMakeLists.txt	2021-08-12 12:35:44.904613229 -0500
+@@ -41,6 +41,9 @@ option(CGAL_HEADER_ONLY "Enable header-o
+ #
+ #--------------------------------------------------------------------------------------------------
+ 
++message( "== Fixing Valgrind Rounding Math Error ==" )
++add_definitions(-DCGAL_DISABLE_ROUNDING_MATH_CHECK)
++
+ message( "== Setting paths ==" )
+ 
+ if ( CGAL_BRANCH_BUILD )

--- a/SPECS/CGAL.spec
+++ b/SPECS/CGAL.spec
@@ -1,5 +1,4 @@
 %global fullversion %{rpmbuild_version}
-#global fullversion 5.2-beta1
 
 
 Name:           CGAL
@@ -10,6 +9,9 @@ Summary:        Computational Geometry Algorithms Library
 License:        LGPLv3+ and GPLv3+ and Boost
 URL:            http://www.cgal.org/
 Source0:        https://github.com/CGAL/cgal/releases/download/releases/%{name}-%{fullversion}/%{name}-%{fullversion}.tar.xz
+
+# Patch for rounding math error
+Patch0:         cgal-rounding-math.patch
 
 # Required devel packages.
 BuildRequires: cmake3
@@ -58,6 +60,7 @@ CGAL algorithms.
 
 %prep
 %setup -q -n %{name}-%{fullversion}
+%patch0
 %{__mkdir} build
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ x-rpmbuild:
       version: &passenger_version '6.0.9-1'
     postgis:
       image: rpmbuild-postgis
-      version: &postgis_version '3.1.2-1'
+      version: &postgis_version '3.1.3-1'
       defines:
         gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ x-rpmbuild:
   rpms:
     CGAL:
       image: rpmbuild-cgal
-      version: &CGAL_version '4.14.3-1'
+      version: &CGAL_version '4.14.3-2'
     FileGDBAPI:
       image: rpmbuild-generic
       version: &FileGDBAPI_version '1.5.1-1'


### PR DESCRIPTION
When running software built using CGAL from `geoint-deps` through tools like `valgrind` an error stops it from processing:
```
Explanation: Wrong rounding: did you forget the  -frounding-math  option if you use GCC?
/usr/bin/bash: line 1:   707 Aborted                 valgrind ...
.terminate called after throwing an instance of 'CGAL::Assertion_exception'
  what():  CGAL ERROR: assertion violation!
Expr: -CGAL_IA_MUL(-1.1, 10.1) != CGAL_IA_MUL(1.1, 10.1)
File: /rpmbuild/BUILD/CGAL-4.14.3/include/CGAL/Interval_nt.h
Line: 210
```
This patch turns off the check that is failing.  This doesn't cause the software to function any differently than before other than when the `GCAL::Interval_nt` object is created it doesn't run a check against the floating point environment (FENV) that isn't properly handled in GCC.  We understand this issue and are able to use CGAL without issue.  We can turn off the failure warning with no adverse effects.

While testing GDAL that depends on this package, I found that no other changes needed to be made nor did GDAL have to be recompiled with these change.  An new CGAL RPM could be made with a new release version replacing the `4.14.2-1` version with version `4.14.3-2` and everything works like a charm.

For more information see:
https://github.com/CGAL/cgal/issues/3180

Closes:
https://github.com/ngageoint/hootenanny/issues/4942