### PR TITLE
PyOsmium 3.2.0

### DIFF
--- a/SPECS/python3-osmium.spec
+++ b/SPECS/python3-osmium.spec
@@ -31,6 +31,8 @@ BuildRequires:  python36-nose
 BuildRequires:  python36-requests
 BuildRequires:  zlib-devel
 
+Requires:       python36-requests
+
 %description
 Provides Python bindings for the Libosmium C++ library, a library
 for working with OpenStreetMap data in a fast and flexible manner.

--- a/SPECS/python3-osmium.spec
+++ b/SPECS/python3-osmium.spec
@@ -28,6 +28,7 @@ BuildRequires:  libosmium-devel >= %{libosmium_min_version}
 BuildRequires:  protozero-devel >= %{protozero_min_version}
 BuildRequires:  python3-devel
 BuildRequires:  python36-nose
+BuildRequires:  python36-requests
 BuildRequires:  zlib-devel
 
 %description

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,11 +176,11 @@ x-rpmbuild:
         commit: '7da019cf9eb12af8f8aa88b7d75789dfcd1e901b'
     python3-osmium:
       image: rpmbuild-pyosmium
-      version: &pyosmium_version '3.1.3-1'
+      version: &pyosmium_version '3.2.0-1'
       defines:
         libosmium_min_version: *libosmium_min_version
         protozero_min_version: *protozero_min_version
-        pybind11_version: '2.6.2'
+        pybind11_version: '2.7.1'
     ruby:
       image: rpmbuild-ruby
       version: &ruby_version '2.7.3-2'

--- a/docker/Dockerfile.rpmbuild
+++ b/docker/Dockerfile.rpmbuild
@@ -31,6 +31,7 @@ ENV LANG=${rpmbuild_lang} \
 # Install basic development and RPM authoring tools.
 RUN --mount=type=cache,target=/var/cache/yum \
     yum-config-manager --save \
+        --setopt=keepcache=1 \
         --setopt=base.repo_gpgcheck=1 \
         --setopt=extras.repo_gpgcheck=1 \
         --setopt=updates.repo_gpgcheck=1 &> /dev/null && \


### PR DESCRIPTION
Upgrades us to 3.2.0, and now the module explicitly requires `requests` and opt-in to keep the yum cache here too.