### PR TITLE
osm2pgsql 1.5.1

### DIFF
--- a/SOURCES/osm2pgsql-replication-analyze.patch
+++ b/SOURCES/osm2pgsql-replication-analyze.patch
@@ -1,0 +1,49 @@
+From: Jochen Topf <jochen@topf.org>
+Date: Tue, 24 Aug 2021 11:25:15 +0200
+Subject: Run ANALYZE on middle tables only in create mode
+
+Fixes #1556
+---
+ src/middle-pgsql.cpp | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/src/middle-pgsql.cpp b/src/middle-pgsql.cpp
+index 12fc036f..7ee7b2da 100644
+--- a/src/middle-pgsql.cpp
++++ b/src/middle-pgsql.cpp
+@@ -563,7 +563,7 @@ void middle_pgsql_t::relation_delete(osmid_t osm_id)
+ void middle_pgsql_t::after_nodes()
+ {
+     m_db_copy.sync();
+-    if (m_options->flat_node_file.empty()) {
++    if (!m_options->append && m_options->flat_node_file.empty()) {
+         auto const &table = m_tables.nodes();
+         analyze_table(m_db_connection, table.schema(), table.name());
+     }
+@@ -572,15 +572,19 @@ void middle_pgsql_t::after_nodes()
+ void middle_pgsql_t::after_ways()
+ {
+     m_db_copy.sync();
+-    auto const &table = m_tables.ways();
+-    analyze_table(m_db_connection, table.schema(), table.name());
++    if (!m_options->append) {
++        auto const &table = m_tables.ways();
++        analyze_table(m_db_connection, table.schema(), table.name());
++    }
+ }
+ 
+ void middle_pgsql_t::after_relations()
+ {
+     m_db_copy.sync();
+-    auto const &table = m_tables.relations();
+-    analyze_table(m_db_connection, table.schema(), table.name());
++    if (!m_options->append) {
++        auto const &table = m_tables.relations();
++        analyze_table(m_db_connection, table.schema(), table.name());
++    }
+ 
+     // release the copy thread and its database connection
+     m_copy_thread->finish();
+-- 
+2.30.2
+

--- a/SOURCES/osm2pgsql-replication-older-python.patch
+++ b/SOURCES/osm2pgsql-replication-older-python.patch
@@ -1,0 +1,25 @@
+From: Amanda McCann <amanda@technomancy.org>
+Date: Wed, 4 Aug 2021 10:05:08 +0200
+Subject: support older versions of python
+
+Older versions don't have .fromisoformat() function
+---
+ scripts/osm2pgsql-replication | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/osm2pgsql-replication b/scripts/osm2pgsql-replication
+index a848f369..06cd81f8 100755
+--- a/scripts/osm2pgsql-replication
++++ b/scripts/osm2pgsql-replication
+@@ -77,7 +77,7 @@ def compute_database_date(conn, prefix):
+     LOG.debug("Found timestamp %s", date)
+ 
+     try:
+-        date = dt.datetime.fromisoformat(date.replace('Z', '+00:00'))
++        date = dt.datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=dt.timezone.utc)
+     except ValueError:
+         LOG.fatal("Cannot parse timestamp '%s'", date)
+         return None
+-- 
+2.30.2
+

--- a/SOURCES/osm2pgsql-replication-osm-server.patch
+++ b/SOURCES/osm2pgsql-replication-osm-server.patch
@@ -1,0 +1,41 @@
+diff --git a/scripts/osm2pgsql-replication b/scripts/osm2pgsql-replication
+index edf2909d..a91f9d1b 100755
+--- a/scripts/osm2pgsql-replication
++++ b/scripts/osm2pgsql-replication
+@@ -68,7 +68,7 @@ def connect(args):
+                             host=args.host, port=args.port)
+ 
+ 
+-def compute_database_date(conn, prefix):
++def compute_database_date(conn, prefix, osm_server):
+     """ Determine the date of the database from the newest object in the
+         database.
+     """
+@@ -84,7 +84,7 @@ def compute_database_date(conn, prefix):
+ 
+     LOG.debug("Using way id %d for timestamp lookup", osmid)
+     # Get the way from the API to find the timestamp when it was created.
+-    url = 'https://www.openstreetmap.org/api/0.6/way/{}/1'.format(osmid)
++    url = '{}/api/0.6/way/{}/1'.format(osm_server, osmid)
+     headers = {"User-Agent" : "osm2pgsql-update",
+                "Accept" : "application/json"}
+     with urlrequest.urlopen(urlrequest.Request(url, headers=headers)) as response:
+@@ -263,7 +263,7 @@ def init(conn, args):
+     this with the '--server' parameter.
+     """
+     if args.osm_file is None:
+-        date = compute_database_date(conn, args.prefix)
++        date = compute_database_date(conn, args.prefix, args.osm_server)
+         if date is None:
+             return 1
+ 
+@@ -439,6 +439,9 @@ def get_parser():
+                           formatter_class=RawDescriptionHelpFormatter,
+                           add_help=False)
+     grp = cmd.add_argument_group('Replication source arguments')
++    grp.add_argument('--osm-server', metavar='URL',
++                     default='https://www.openstreetmap.org',
++                     help='Use OpenStreetMap server at the given URL (default: %(default)s)')
+     srcgrp = grp.add_mutually_exclusive_group()
+     srcgrp.add_argument('--osm-file', metavar='FILE',
+                         help='Get replication information from the given file.')

--- a/SOURCES/osm2pgsql-replication-prefix-argument.patch
+++ b/SOURCES/osm2pgsql-replication-prefix-argument.patch
@@ -1,0 +1,57 @@
+From: Amanda McCann <amanda@technomancy.org>
+Date: Thu, 12 Aug 2021 17:31:45 +0200
+Subject: Add -p (for --prefix) argument for osm2pgsql-replication too
+
+Regular osm2pgsql takes -p as an alias for --prefix, so make them match
+---
+ docs/osm2pgsql-replication.1  | 6 +++---
+ scripts/osm2pgsql-replication | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/docs/osm2pgsql-replication.1 b/docs/osm2pgsql-replication.1
+index c0053b9d..29e5a975 100644
+--- a/docs/osm2pgsql-replication.1
++++ b/docs/osm2pgsql-replication.1
+@@ -35,7 +35,7 @@ how to use osm2pgsql\-replication.
+     Download newly available data and apply it to the database.
+ .SH OPTIONS 'osm2pgsql-replication init'
+ usage: osm2pgsql-replication init [-h] [-q] [-v] [-d DB] [-U NAME] [-H HOST]
+-                                  [-P PORT] [--prefix PREFIX]
++                                  [-P PORT] [-p PREFIX]
+                                   [--osm-file FILE | --server URL]
+ 
+ Initialise the replication process.
+@@ -93,7 +93,7 @@ Database server host name or socket location
+ Database server port
+ 
+ .TP
+-\fB\-\-prefix\fR PREFIX
++\fB\-p\fR PREFIX, \fB\-\-prefix\fR PREFIX
+ Prefix for table names (default 'planet_osm')
+ 
+ .TP
+@@ -174,7 +174,7 @@ Database server host name or socket location
+ Database server port
+ 
+ .TP
+-\fB\-\-prefix\fR PREFIX
++\fB\-p\fR PREFIX, \fB\-\-prefix\fR PREFIX
+ Prefix for table names (default 'planet_osm')
+ 
+ .SH DISTRIBUTION
+diff --git a/scripts/osm2pgsql-replication b/scripts/osm2pgsql-replication
+index 06cd81f8..fc8cd0e1 100755
+--- a/scripts/osm2pgsql-replication
++++ b/scripts/osm2pgsql-replication
+@@ -300,7 +300,7 @@ def get_parser():
+                        help='Database server host name or socket location')
+     group.add_argument('-P', '--port', metavar='PORT',
+                        help='Database server port')
+-    group.add_argument('--prefix', metavar='PREFIX', default='planet_osm',
++    group.add_argument('-p', '--prefix', metavar='PREFIX', default='planet_osm',
+                        help="Prefix for table names (default 'planet_osm')")
+ 
+     # Arguments for init
+-- 
+2.30.2
+

--- a/SOURCES/osm2pgsql-replication-status.patch
+++ b/SOURCES/osm2pgsql-replication-status.patch
@@ -1,0 +1,177 @@
+From: Amanda McCann <amanda@technomancy.org>
+Date: Wed, 18 Aug 2021 11:39:28 +0200
+Subject: Add 'status' command to osm2pgsql-replication
+
+Prints the current replication status, and with --json prints that as
+JSON data
+---
+ scripts/osm2pgsql-replication | 139 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 257 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/osm2pgsql-replication b/scripts/osm2pgsql-replication
+index fc8cd0e1..edf2909d 100755
+--- a/scripts/osm2pgsql-replication
++++ b/scripts/osm2pgsql-replication
+@@ -39,6 +39,28 @@ from osmium import WriteHandler
+ 
+ LOG = logging.getLogger()
+ 
++def pretty_format_timedelta(seconds):
++    minutes = int(seconds/60)
++    (hours, minutes) = divmod(minutes, 60)
++    (days, hours) = divmod(hours, 24)
++    (weeks, days) = divmod(days, 7)
++
++    if 0 < seconds < 60:
++        output = "<1 minute"
++    else:
++        output = []
++        # If weeks > 1 but hours == 0, we still want to show "0 hours"
++        if weeks > 0:
++            output.append("{} week(s)".format(weeks))
++        if days > 0 or weeks > 0:
++            output.append("{} day(s)".format(days))
++        if hours > 0 or days > 0 or weeks > 0:
++            output.append("{} hour(s)".format(hours))
++
++        output.append("{} minute(s)".format(minutes))
++        output = " ".join(output)
++    return output
++
+ def connect(args):
+     """ Create a connection from the given command line arguments.
+     """
+@@ -115,6 +137,113 @@ def update_replication_state(conn, table, seq, date):
+ 
+     conn.commit()
+ 
++def status(conn, args):
++    """\
++    Print information about the current replication status, optionally as JSON.
++
++    Sample output:
++
++        2021-08-17 15:20:28 [INFO]: Using replication service 'https://planet.openstreetmap.org/replication/minute', which is at sequence 4675115 ( 2021-08-17T13:19:43Z )
++        2021-08-17 15:20:28 [INFO]: Replication server's most recent data is <1 minute old
++        2021-08-17 15:20:28 [INFO]: Local database is 8288 sequences behind the server, i.e. 5 day(s) 20 hour(s) 58 minute(s)
++        2021-08-17 15:20:28 [INFO]: Local database's most recent data is 5 day(s) 20 hour(s) 59 minute(s) old
++
++
++    With the '--json' option, the status is printed as a json object.
++
++        {
++          "server": {
++            "base_url": "https://planet.openstreetmap.org/replication/minute",
++            "sequence": 4675116,
++            "timestamp": "2021-08-17T13:20:43Z",
++            "age_sec": 27
++          },
++          "local": {
++            "sequence": 4666827,
++            "timestamp": "2021-08-11T16:21:09Z",
++            "age_sec": 507601
++          },
++          "status": 0
++        }
++
++
++    'status' is 0 if there were no problems getting the status. 1 & 2 for
++    improperly set up replication. 3 for network issues. If status ≠ 0, then
++    the 'error' key is an error message (as string). 'status' is used as the
++    exit code.
++
++    'server' is the replication server's current status. 'sequence' is it's
++    sequence number, 'timestamp' the time of that, and 'age_sec' the age of the
++    data in seconds.
++
++    'local' is the status of your server.
++    """
++
++    results = {}
++
++    with conn.cursor() as cur:
++        cur.execute('SELECT * FROM pg_tables where tablename = %s', (args.table, ))
++        if cur.rowcount < 1:
++            results['status'] = 1
++            results['error'] = "Cannot find replication status table. Run 'osm2pgsql-replication init' first."
++        else:
++            cur.execute('SELECT * FROM "{}"'.format(args.table))
++            if cur.rowcount != 1:
++                results['status'] = 2
++                results['error'] = "Updates not set up correctly. Run 'osm2pgsql-updates init' first."
++            else:
++
++                base_url, db_seq, db_ts = cur.fetchone()
++                db_ts = db_ts.astimezone(dt.timezone.utc)
++                results['server'] = {}
++                results['local'] = {}
++                results['server']['base_url'] = base_url
++                results['local']['sequence'] = db_seq
++                results['local']['timestamp'] = db_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
++
++
++                repl = ReplicationServer(base_url)
++                state_info = repl.get_state_info()
++                if state_info is None:
++                    # PyOsmium was unable to download the state information
++                    results['status'] = 3
++                    results['error'] = "Unable to download the state information from {}".format(base_url)
++                else:
++                    results['status'] = 0
++                    now = dt.datetime.now(dt.timezone.utc)
++
++                    server_seq, server_ts = state_info
++                    server_ts = server_ts.astimezone(dt.timezone.utc)
++
++                    results['server']['sequence'] = server_seq
++                    results['server']['timestamp'] = server_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
++                    results['server']['age_sec'] = int((now-server_ts).total_seconds())
++
++                    results['local']['age_sec'] = int((now - db_ts).total_seconds())
++
++    if args.json:
++        print(json.dumps(results))
++    else:
++        if results['status'] != 0:
++            LOG.fatal(results['error'])
++        else:
++            print("Using replication service '{}', which is at sequence {} ( {} )".format(
++                     results['server']['base_url'], results['server']['sequence'], results['server']['timestamp']))
++            print("Replication server's most recent data is {} old".format(pretty_format_timedelta(results['server']['age_sec'])))
++
++            if results['local']['sequence'] == results['server']['sequence']:
++                print("Local database is up to date with server")
++            else:
++                print("Local database is {} sequences behind the server, i.e. {}".format(
++                        results['server']['sequence'] - results['local']['sequence'],
++                        pretty_format_timedelta(results['local']['age_sec'] - results['server']['age_sec'])
++                    ))
++
++            print("Local database's most recent data is {} old".format(pretty_format_timedelta(results['local']['age_sec'])))
++
++
++    return results['status']
++
+ 
+ def init(conn, args):
+     """\
+@@ -340,6 +469,16 @@ def get_parser():
+     cmd.add_argument('--post-processing', metavar='SCRIPT',
+                      help='Post-processing script to run after each execution of osm2pgsql.')
+ 
++    # Arguments for status
++    cmd = subs.add_parser('status', parents=[default_args],
++                          help=status.__doc__.split('\n', 1)[0],
++                          description=dedent(status.__doc__),
++                          formatter_class=RawDescriptionHelpFormatter,
++                          add_help=False)
++    cmd.add_argument('--json', action="store_true", default=False, help="Output status as json.")
++    cmd.set_defaults(handler=status)
++
++
+     return parser
+ 
+ def main():
+-- 
+2.30.2
+

--- a/SPECS/osm2pgsql.spec
+++ b/SPECS/osm2pgsql.spec
@@ -15,6 +15,11 @@ Summary:        Imports map data from OpenStreetMap to a PostgreSQL database
 License:        GPLv2+
 URL:            https://github.com/openstreetmap/osm2pgsql
 Source0:        https://github.com/openstreetmap/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+Patch0:         osm2pgsql-replication-prefix-argument.patch
+Patch1:         osm2pgsql-replication-status.patch
+Patch2:         osm2pgsql-replication-analyze.patch
+Patch3:         osm2pgsql-replication-older-python.patch
+Patch4:         osm2pgsql-replication-osm-server.patch
 
 BuildRequires:  boost-devel
 BuildRequires:  bzip2-devel
@@ -84,7 +89,7 @@ pushd build
 %if %{with db_tests}
 export PGDATA="${HOME}/pgdata"
 pg_ctl -s stop || true
-%{__rm} -fr ${PGDATA}
+%{__rm} -fr ${PGDATA} /tmp/psql-tablespace
 # Create PostgreSQL database.
 initdb --encoding UTF-8 --locale en_US.UTF-8
 
@@ -97,7 +102,7 @@ echo "listen_addresses = '127.0.0.1'" >> "${PGDATA}/postgresql.conf"
 pg_ctl start
 
 # Create testing tablespace required by the osm2pgsql tests.
-%{__mkdir_p} "/tmp/psql-tablespace"
+%{__mkdir_p} /tmp/psql-tablespace
 psql -d postgres -c "CREATE TABLESPACE tablespacetest LOCATION '/tmp/psql-tablespace'"
 
 # Set the SMP flags so only one process is used for the tests, otherwise database

--- a/SPECS/osm2pgsql.spec
+++ b/SPECS/osm2pgsql.spec
@@ -40,13 +40,24 @@ BuildRequires:  postgresql%{postgres_dotless}-server
 BuildRequires:  python3-psycopg2
 %endif
 
-
 %description
 Processes the planet file from the community mapping project at
 http://www.openstreetmap.org. The map data is converted from XML to a
 database stored in PostgreSQL with PostGIS geospatial extensions. This
 database may then be used to render maps with Mapnik or for other
 geospatial analysis.
+
+%package replication
+Summary:        Update an osm2pgsql database with changes from a OSM replication server.
+Requires:	%{name} = %{version}-%{release}
+Requires:       python3-osmium
+Requires:       python3-psycopg2
+
+%description replication
+This tool initialises the updating process by looking at the import file
+or the newest object in the database. The state is then saved in a table
+in the database. Subsequent runs download newly available data and apply
+it to the database.
 
 
 %prep
@@ -110,6 +121,7 @@ pushd build
 %cmake3_install
 %{_bindir}/find %{buildroot} -name '*.la' -delete
 popd
+%{__install} -m 0755 scripts/osm2pgsql-replication %{buildroot}/%{_bindir}
 
 
 %files
@@ -118,6 +130,9 @@ popd
 %{_mandir}/man1/%{name}.1*
 %{_bindir}/%{name}
 %{_datadir}/%{name}/
+
+%files replication
+%{_bindir}/osm2pgsql-replication
 
 
 %changelog

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ x-rpmbuild:
         protozero_min_version: *protozero_min_version
     osm2pgsql:
       image: rpmbuild-osm2pgsql
-      version: &osm2pgsql_version '1.5.0-1'
+      version: &osm2pgsql_version '1.5.1-1'
       defines:
         libosmium_min_version: '2.17.0'
         proj_min_version: *proj_min_version

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -170,8 +170,14 @@ Its data package contains archives that are public domain and
 ## osm2pgsql
 
 The [osm2pgsql](https://github.com/openstreetmap/osm2pgsql) source archives are
-obtained directly from GitHub and is
+obtained directly from GitHub and are
 [GPLv2 licensed](https://github.com/openstreetmap/osm2pgsql/blob/master/COPYING).
+Using the same license, the following patch files were derived from changesets in GitHub:
+
+* [`osm2pgsql-replication-analyze.patch`](../SOURCES/osm2pgsql-replication-analyze.patch)
+* [`osm2pgsql-replication-older-python.patch`](../SOURCES/osm2pgsql-replication-older-python.patch)
+* [`osm2pgsql-replication-prefix-argument.patch`](../SOURCES/osm2pgsql-replication-prefix-argument.patch)
+* [`osm2pgsql-replication-status.patch`](../SOURCES/osm2pgsql-replication-status.patch)
 
 The [`osm2pgsql.spec`](../SPECS/osm2pgsql.spec) originates from
 [Fedora's `osm2pgsql` RPM](https://src.fedoraproject.org/rpms/osm2pgsql)


### PR DESCRIPTION
Upgrades `osm2pgsql` to 1.5.1, and include patches for the very new `osm2pgsql-replication` script (which depends on PyOsmium).