### PR TITLE
Ruby 2.7.3-3 

### DIFF
--- a/SOURCES/rubygems-date-cve-2021-41817.patch
+++ b/SOURCES/rubygems-date-cve-2021-41817.patch
@@ -1,0 +1,1112 @@
+Backport of date 3.0.2 gem to fix CVE-2021-41817.
+
+diff --git a/ext/date/date.gemspec b/ext/date/date.gemspec
+index bd323b7..a7e110a 100644
+--- a/ext/date/date.gemspec
++++ b/ext/date/date.gemspec
+@@ -1,7 +1,7 @@
+ # frozen_string_literal: true
+ Gem::Specification.new do |s|
+   s.name = "date"
+-  s.version = '3.0.0'
++  s.version = '3.0.2'
+   s.summary = "A subclass of Object includes Comparable module for handling dates."
+   s.description = "A subclass of Object includes Comparable module for handling dates."
+ 
+diff --git a/ext/date/date_core.c b/ext/date/date_core.c
+index ccac90a..3917f3e 100644
+--- a/ext/date/date_core.c
++++ b/ext/date/date_core.c
+@@ -11,6 +11,7 @@
+ #include <sys/time.h>
+ #endif
+ 
++#undef NDEBUG
+ #define NDEBUG
+ #include <assert.h>
+ 
+@@ -4321,12 +4322,40 @@ date_s_strptime(int argc, VALUE *argv, VALUE klass)
+ 
+ VALUE date__parse(VALUE str, VALUE comp);
+ 
++static size_t
++get_limit(VALUE opt)
++{
++    if (!NIL_P(opt)) {
++        VALUE limit = rb_hash_aref(opt, ID2SYM(rb_intern("limit")));
++        if (NIL_P(limit)) return SIZE_MAX;
++        return NUM2SIZET(limit);
++    }
++    return 128;
++}
++
++static void
++check_limit(VALUE str, VALUE opt)
++{
++    if (NIL_P(str)) return;
++    if (SYMBOL_P(str)) str = rb_sym2str(str);
++
++    StringValue(str);
++    size_t slen = RSTRING_LEN(str);
++    size_t limit = get_limit(opt);
++    if (slen > limit) {
++	rb_raise(rb_eArgError,
++		 "string length (%"PRI_SIZE_PREFIX"u) exceeds the limit %"PRI_SIZE_PREFIX"u", slen, limit);
++    }
++}
++
+ static VALUE
+ date_s__parse_internal(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE vstr, vcomp, hash;
++    VALUE vstr, vcomp, hash, opt;
+ 
+-    rb_scan_args(argc, argv, "11", &vstr, &vcomp);
++    rb_scan_args(argc, argv, "11:", &vstr, &vcomp, &opt);
++    if (!NIL_P(opt)) argc--;
++    check_limit(vstr, opt);
+     StringValue(vstr);
+     if (!rb_enc_str_asciicompat_p(vstr))
+ 	rb_raise(rb_eArgError,
+@@ -4341,7 +4370,7 @@ date_s__parse_internal(int argc, VALUE *argv, VALUE klass)
+ 
+ /*
+  * call-seq:
+- *    Date._parse(string[, comp=true])  ->  hash
++ *    Date._parse(string[, comp=true], limit: 128)  ->  hash
+  *
+  * Parses the given representation of date and time, and returns a
+  * hash of parsed elements.  This method does not function as a
+@@ -4352,6 +4381,10 @@ date_s__parse_internal(int argc, VALUE *argv, VALUE klass)
+  * it full.
+  *
+  *    Date._parse('2001-02-03')	#=> {:year=>2001, :mon=>2, :mday=>3}
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s__parse(int argc, VALUE *argv, VALUE klass)
+@@ -4361,7 +4394,7 @@ date_s__parse(int argc, VALUE *argv, VALUE klass)
+ 
+ /*
+  * call-seq:
+- *    Date.parse(string='-4712-01-01'[, comp=true[, start=Date::ITALY]])  ->  date
++ *    Date.parse(string='-4712-01-01'[, comp=true[, start=Date::ITALY]], limit: 128)  ->  date
+  *
+  * Parses the given representation of date and time, and creates a
+  * date object.  This method does not function as a validator.
+@@ -4373,13 +4406,18 @@ date_s__parse(int argc, VALUE *argv, VALUE klass)
+  *    Date.parse('2001-02-03')		#=> #<Date: 2001-02-03 ...>
+  *    Date.parse('20010203')		#=> #<Date: 2001-02-03 ...>
+  *    Date.parse('3rd Feb 2001')	#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_parse(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, comp, sg;
++    VALUE str, comp, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "03", &str, &comp, &sg);
++    rb_scan_args(argc, argv, "03:", &str, &comp, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4391,11 +4429,12 @@ date_s_parse(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE argv2[2], hash;
+-
+-	argv2[0] = str;
+-	argv2[1] = comp;
+-	hash = date_s__parse(2, argv2, klass);
++        int argc2 = 2;
++	VALUE argv2[3];
++        argv2[0] = str;
++        argv2[1] = comp;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__parse(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+@@ -4409,19 +4448,28 @@ VALUE date__jisx0301(VALUE);
+ 
+ /*
+  * call-seq:
+- *    Date._iso8601(string)  ->  hash
++ *    Date._iso8601(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__iso8601(VALUE klass, VALUE str)
++date_s__iso8601(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__iso8601(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.iso8601(string='-4712-01-01'[, start=Date::ITALY])  ->  date
++ *    Date.iso8601(string='-4712-01-01'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical ISO 8601 formats.
+@@ -4429,13 +4477,18 @@ date_s__iso8601(VALUE klass, VALUE str)
+  *    Date.iso8601('2001-02-03')	#=> #<Date: 2001-02-03 ...>
+  *    Date.iso8601('20010203')		#=> #<Date: 2001-02-03 ...>
+  *    Date.iso8601('2001-W05-6')	#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_iso8601(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4445,38 +4498,56 @@ date_s_iso8601(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__iso8601(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__iso8601(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._rfc3339(string)  ->  hash
++ *    Date._rfc3339(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__rfc3339(VALUE klass, VALUE str)
++date_s__rfc3339(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__rfc3339(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.rfc3339(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  date
++ *    Date.rfc3339(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical RFC 3339 formats.
+  *
+  *    Date.rfc3339('2001-02-03T04:05:06+07:00')	#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_rfc3339(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4486,38 +4557,56 @@ date_s_rfc3339(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__rfc3339(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__rfc3339(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._xmlschema(string)  ->  hash
++ *    Date._xmlschema(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__xmlschema(VALUE klass, VALUE str)
++date_s__xmlschema(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__xmlschema(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.xmlschema(string='-4712-01-01'[, start=Date::ITALY])  ->  date
++ *    Date.xmlschema(string='-4712-01-01'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical XML Schema formats.
+  *
+  *    Date.xmlschema('2001-02-03')	#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_xmlschema(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4527,41 +4616,58 @@ date_s_xmlschema(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__xmlschema(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__xmlschema(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._rfc2822(string)  ->  hash
+- *    Date._rfc822(string)   ->  hash
++ *    Date._rfc2822(string, limit: 128)  ->  hash
++ *    Date._rfc822(string, limit: 128)   ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__rfc2822(VALUE klass, VALUE str)
++date_s__rfc2822(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__rfc2822(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.rfc2822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY])  ->  date
+- *    Date.rfc822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY])   ->  date
++ *    Date.rfc2822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY], limit: 128)  ->  date
++ *    Date.rfc822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY], limit: 128)   ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical RFC 2822 formats.
+  *
+  *    Date.rfc2822('Sat, 3 Feb 2001 00:00:00 +0000')
+  *						#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
+ 
+     switch (argc) {
+       case 0:
+@@ -4571,39 +4677,56 @@ date_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__rfc2822(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__rfc2822(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._httpdate(string)  ->  hash
++ *    Date._httpdate(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__httpdate(VALUE klass, VALUE str)
++date_s__httpdate(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__httpdate(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.httpdate(string='Mon, 01 Jan -4712 00:00:00 GMT'[, start=Date::ITALY])  ->  date
++ *    Date.httpdate(string='Mon, 01 Jan -4712 00:00:00 GMT'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some RFC 2616 format.
+  *
+  *    Date.httpdate('Sat, 03 Feb 2001 00:00:00 GMT')
+  *						#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_httpdate(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
+ 
+     switch (argc) {
+       case 0:
+@@ -4613,26 +4736,39 @@ date_s_httpdate(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__httpdate(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__httpdate(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    Date._jisx0301(string)  ->  hash
++ *    Date._jisx0301(string, limit: 128)  ->  hash
+  *
+  * Returns a hash of parsed elements.
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+-date_s__jisx0301(VALUE klass, VALUE str)
++date_s__jisx0301(int argc, VALUE *argv, VALUE klass)
+ {
++    VALUE str, opt;
++
++    rb_scan_args(argc, argv, "1:", &str, &opt);
++    check_limit(str, opt);
++
+     return date__jisx0301(str);
+ }
+ 
+ /*
+  * call-seq:
+- *    Date.jisx0301(string='-4712-01-01'[, start=Date::ITALY])  ->  date
++ *    Date.jisx0301(string='-4712-01-01'[, start=Date::ITALY], limit: 128)  ->  date
+  *
+  * Creates a new Date object by parsing from a string according to
+  * some typical JIS X 0301 formats.
+@@ -4642,13 +4778,18 @@ date_s__jisx0301(VALUE klass, VALUE str)
+  * For no-era year, legacy format, Heisei is assumed.
+  *
+  *    Date.jisx0301('13.02.03') 		#=> #<Date: 2001-02-03 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ date_s_jisx0301(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -4658,7 +4799,11 @@ date_s_jisx0301(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__jisx0301(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        if (!NIL_P(opt)) argv2[argc2++] = opt;
++	VALUE hash = date_s__jisx0301(argc2, argv2, klass);
+ 	return d_new_by_frags(klass, hash, sg);
+     }
+ }
+@@ -7201,11 +7346,14 @@ d_lite_marshal_load(VALUE self, VALUE a)
+ 
+     if (simple_dat_p(dat)) {
+ 	if (df || !f_zero_p(sf) || of) {
+-	    rb_raise(rb_eArgError,
+-		     "cannot load complex into simple");
++	    /* loading a fractional date; promote to complex */
++	    dat = ruby_xrealloc(dat, sizeof(struct ComplexDateData));
++	    RTYPEDDATA(self)->data = dat;
++	    goto complex_data;
+ 	}
+ 	set_to_simple(self, &dat->s, nth, jd, sg, 0, 0, 0, HAVE_JD);
+     } else {
++      complex_data:
+ 	set_to_complex(self, &dat->c, nth, jd, df, sf, of, sg,
+ 		       0, 0, 0, 0, 0, 0,
+ 		       HAVE_JD | HAVE_DF);
+@@ -7994,7 +8142,7 @@ datetime_s_strptime(int argc, VALUE *argv, VALUE klass)
+ 
+ /*
+  * call-seq:
+- *    DateTime.parse(string='-4712-01-01T00:00:00+00:00'[, comp=true[, start=Date::ITALY]])  ->  datetime
++ *    DateTime.parse(string='-4712-01-01T00:00:00+00:00'[, comp=true[, start=Date::ITALY]], limit: 128)  ->  datetime
+  *
+  * Parses the given representation of date and time, and creates a
+  * DateTime object.  This method does not function as a validator.
+@@ -8008,13 +8156,18 @@ datetime_s_strptime(int argc, VALUE *argv, VALUE klass)
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  *    DateTime.parse('3rd Feb 2001 04:05:06 PM')
+  *				#=> #<DateTime: 2001-02-03T16:05:06+00:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_parse(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, comp, sg;
++    VALUE str, comp, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "03", &str, &comp, &sg);
++    rb_scan_args(argc, argv, "03:", &str, &comp, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8026,18 +8179,20 @@ datetime_s_parse(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE argv2[2], hash;
+-
+-	argv2[0] = str;
+-	argv2[1] = comp;
+-	hash = date_s__parse(2, argv2, klass);
++        int argc2 = 2;
++        VALUE argv2[3];
++        argv2[0] = str;
++        argv2[1] = comp;
++        argv2[2] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__parse(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.iso8601(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  datetime
++ *    DateTime.iso8601(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical ISO 8601 formats.
+@@ -8048,13 +8203,18 @@ datetime_s_parse(int argc, VALUE *argv, VALUE klass)
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  *    DateTime.iso8601('2001-W05-6T04:05:06+07:00')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_iso8601(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8064,27 +8224,37 @@ datetime_s_iso8601(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__iso8601(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2--;
++	VALUE hash = date_s__iso8601(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.rfc3339(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  datetime
++ *    DateTime.rfc3339(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical RFC 3339 formats.
+  *
+  *    DateTime.rfc3339('2001-02-03T04:05:06+07:00')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_rfc3339(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8094,27 +8264,37 @@ datetime_s_rfc3339(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__rfc3339(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__rfc3339(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.xmlschema(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  datetime
++ *    DateTime.xmlschema(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical XML Schema formats.
+  *
+  *    DateTime.xmlschema('2001-02-03T04:05:06+07:00')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_xmlschema(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8124,28 +8304,38 @@ datetime_s_xmlschema(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__xmlschema(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__xmlschema(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.rfc2822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY])  ->  datetime
+- *    DateTime.rfc822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY])   ->  datetime
++ *    DateTime.rfc2822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY], limit: 128)  ->  datetime
++ *    DateTime.rfc822(string='Mon, 1 Jan -4712 00:00:00 +0000'[, start=Date::ITALY], limit: 128)   ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical RFC 2822 formats.
+  *
+  *     DateTime.rfc2822('Sat, 3 Feb 2001 04:05:06 +0700')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8155,7 +8345,12 @@ datetime_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__rfc2822(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__rfc2822(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+@@ -8169,13 +8364,18 @@ datetime_s_rfc2822(int argc, VALUE *argv, VALUE klass)
+  *
+  *    DateTime.httpdate('Sat, 03 Feb 2001 04:05:06 GMT')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+00:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_httpdate(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8185,14 +8385,19 @@ datetime_s_httpdate(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__httpdate(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__httpdate(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+ 
+ /*
+  * call-seq:
+- *    DateTime.jisx0301(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY])  ->  datetime
++ *    DateTime.jisx0301(string='-4712-01-01T00:00:00+00:00'[, start=Date::ITALY], limit: 128)  ->  datetime
+  *
+  * Creates a new DateTime object by parsing from a string according to
+  * some typical JIS X 0301 formats.
+@@ -8204,13 +8409,18 @@ datetime_s_httpdate(int argc, VALUE *argv, VALUE klass)
+  *
+  *    DateTime.jisx0301('13.02.03T04:05:06+07:00')
+  *				#=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
++ *
++ * Raise an ArgumentError when the string length is longer than _limit_.
++ * You can stop this check by passing `limit: nil`, but note that
++ * it may take a long time to parse.
+  */
+ static VALUE
+ datetime_s_jisx0301(int argc, VALUE *argv, VALUE klass)
+ {
+-    VALUE str, sg;
++    VALUE str, sg, opt;
+ 
+-    rb_scan_args(argc, argv, "02", &str, &sg);
++    rb_scan_args(argc, argv, "02:", &str, &sg, &opt);
++    if (!NIL_P(opt)) argc--;
+ 
+     switch (argc) {
+       case 0:
+@@ -8220,7 +8430,12 @@ datetime_s_jisx0301(int argc, VALUE *argv, VALUE klass)
+     }
+ 
+     {
+-	VALUE hash = date_s__jisx0301(klass, str);
++        int argc2 = 1;
++        VALUE argv2[2];
++        argv2[0] = str;
++        argv2[1] = opt;
++        if (!NIL_P(opt)) argc2++;
++	VALUE hash = date_s__jisx0301(argc2, argv2, klass);
+ 	return dt_new_by_frags(klass, hash, sg);
+     }
+ }
+@@ -9379,19 +9594,19 @@ Init_date_core(void)
+     rb_define_singleton_method(cDate, "strptime", date_s_strptime, -1);
+     rb_define_singleton_method(cDate, "_parse", date_s__parse, -1);
+     rb_define_singleton_method(cDate, "parse", date_s_parse, -1);
+-    rb_define_singleton_method(cDate, "_iso8601", date_s__iso8601, 1);
++    rb_define_singleton_method(cDate, "_iso8601", date_s__iso8601, -1);
+     rb_define_singleton_method(cDate, "iso8601", date_s_iso8601, -1);
+-    rb_define_singleton_method(cDate, "_rfc3339", date_s__rfc3339, 1);
++    rb_define_singleton_method(cDate, "_rfc3339", date_s__rfc3339, -1);
+     rb_define_singleton_method(cDate, "rfc3339", date_s_rfc3339, -1);
+-    rb_define_singleton_method(cDate, "_xmlschema", date_s__xmlschema, 1);
++    rb_define_singleton_method(cDate, "_xmlschema", date_s__xmlschema, -1);
+     rb_define_singleton_method(cDate, "xmlschema", date_s_xmlschema, -1);
+-    rb_define_singleton_method(cDate, "_rfc2822", date_s__rfc2822, 1);
+-    rb_define_singleton_method(cDate, "_rfc822", date_s__rfc2822, 1);
++    rb_define_singleton_method(cDate, "_rfc2822", date_s__rfc2822, -1);
++    rb_define_singleton_method(cDate, "_rfc822", date_s__rfc2822, -1);
+     rb_define_singleton_method(cDate, "rfc2822", date_s_rfc2822, -1);
+     rb_define_singleton_method(cDate, "rfc822", date_s_rfc2822, -1);
+-    rb_define_singleton_method(cDate, "_httpdate", date_s__httpdate, 1);
++    rb_define_singleton_method(cDate, "_httpdate", date_s__httpdate, -1);
+     rb_define_singleton_method(cDate, "httpdate", date_s_httpdate, -1);
+-    rb_define_singleton_method(cDate, "_jisx0301", date_s__jisx0301, 1);
++    rb_define_singleton_method(cDate, "_jisx0301", date_s__jisx0301, -1);
+     rb_define_singleton_method(cDate, "jisx0301", date_s_jisx0301, -1);
+ 
+     rb_define_method(cDate, "initialize", date_initialize, -1);
+diff --git a/ext/date/date_parse.c b/ext/date/date_parse.c
+index 519f29c..0378e50 100644
+--- a/ext/date/date_parse.c
++++ b/ext/date/date_parse.c
+@@ -70,7 +70,7 @@ static size_t
+ digit_span(const char *s, const char *e)
+ {
+     size_t i = 0;
+-    while (s + i < e && isdigit(s[i])) i++;
++    while (s + i < e && isdigit((unsigned char)s[i])) i++;
+     return i;
+ }
+ 
+@@ -110,7 +110,7 @@ s3e(VALUE hash, VALUE y, VALUE m, VALUE d, int bc)
+ 
+ 	s = RSTRING_PTR(y);
+ 	ep = RSTRING_END(y);
+-	while (s < ep && !issign(*s) && !isdigit(*s))
++	while (s < ep && !issign(*s) && !isdigit((unsigned char)*s))
+ 	    s++;
+ 	if (s >= ep) goto no_date;
+ 	bp = s;
+@@ -162,7 +162,7 @@ s3e(VALUE hash, VALUE y, VALUE m, VALUE d, int bc)
+ 
+ 	s = RSTRING_PTR(y);
+ 	ep = RSTRING_END(y);
+-	while (s < ep && !issign(*s) && !isdigit(*s))
++	while (s < ep && !issign(*s) && !isdigit((unsigned char)*s))
+ 	    s++;
+ 	if (s >= ep) goto no_year;
+ 	bp = s;
+@@ -199,7 +199,7 @@ s3e(VALUE hash, VALUE y, VALUE m, VALUE d, int bc)
+ 
+ 	s = RSTRING_PTR(m);
+ 	ep = RSTRING_END(m);
+-	while (s < ep && !isdigit(*s))
++	while (s < ep && !isdigit((unsigned char)*s))
+ 	    s++;
+ 	if (s >= ep) goto no_month;
+ 	bp = s;
+@@ -225,7 +225,7 @@ s3e(VALUE hash, VALUE y, VALUE m, VALUE d, int bc)
+ 
+ 	s = RSTRING_PTR(d);
+ 	ep = RSTRING_END(d);
+-	while (s < ep && !isdigit(*s))
++	while (s < ep && !isdigit((unsigned char)*s))
+ 	    s++;
+ 	if (s >= ep) goto no_mday;
+ 	bp = s;
+@@ -364,9 +364,9 @@ static int
+ str_end_with_word(const char *s, long l, const char *w)
+ {
+     int n = (int)strlen(w);
+-    if (l <= n || !isspace(s[l - n - 1])) return 0;
++    if (l <= n || !isspace((unsigned char)s[l - n - 1])) return 0;
+     if (strncasecmp(&s[l - n], w, n)) return 0;
+-    do ++n; while (l > n && isspace(s[l - n - 1]));
++    do ++n; while (l > n && isspace((unsigned char)s[l - n - 1]));
+     return n;
+ }
+ 
+@@ -376,7 +376,7 @@ shrunk_size(const char *s, long l)
+     long i, ni;
+     int sp = 0;
+     for (i = ni = 0; i < l; ++i) {
+-	if (!isspace(s[i])) {
++	if (!isspace((unsigned char)s[i])) {
+ 	    if (sp) ni++;
+ 	    sp = 0;
+ 	    ni++;
+@@ -394,7 +394,7 @@ shrink_space(char *d, const char *s, long l)
+     long i, ni;
+     int sp = 0;
+     for (i = ni = 0; i < l; ++i) {
+-	if (!isspace(s[i])) {
++	if (!isspace((unsigned char)s[i])) {
+ 	    if (sp) d[ni++] = ' ';
+ 	    sp = 0;
+ 	    d[ni++] = s[i];
+@@ -754,8 +754,8 @@ check_year_width(VALUE y)
+     l = RSTRING_LEN(y);
+     if (l < 2) return 0;
+     s = RSTRING_PTR(y);
+-    if (!isdigit(s[1])) return 0;
+-    return (l == 2 || !isdigit(s[2]));
++    if (!isdigit((unsigned char)s[1])) return 0;
++    return (l == 2 || !isdigit((unsigned char)s[2]));
+ }
+ 
+ static int
+diff --git a/spec/ruby/library/date/strftime_spec.rb b/spec/ruby/library/date/strftime_spec.rb
+index 9d298e4..8b1ebe0 100644
+--- a/spec/ruby/library/date/strftime_spec.rb
++++ b/spec/ruby/library/date/strftime_spec.rb
+@@ -22,9 +22,18 @@ describe "Date#strftime" do
+   end
+ 
+   # %v is %e-%b-%Y for Date/DateTime
+-  it "should be able to show the commercial week" do
+-    @date.strftime("%v").should == " 9-Apr-2000"
+-    @date.strftime("%v").should == @date.strftime('%e-%b-%Y')
++  ruby_version_is ""..."3.1" do
++    it "should be able to show the commercial week" do
++      @date.strftime("%v").should == " 9-Apr-2000"
++      @date.strftime("%v").should == @date.strftime('%e-%b-%Y')
++    end
++  end
++
++  ruby_version_is "3.1" do
++    it "should be able to show the commercial week" do
++      @date.strftime("%v").should == " 9-APR-2000"
++      @date.strftime("%v").should != @date.strftime('%e-%b-%Y')
++    end
+   end
+ 
+   # additional conversion specifiers only in Date/DateTime
+diff --git a/test/date/test_date_parse.rb b/test/date/test_date_parse.rb
+index 9f92635..34a672b 100644
+--- a/test/date/test_date_parse.rb
++++ b/test/date/test_date_parse.rb
+@@ -1,6 +1,7 @@
+ # frozen_string_literal: true
+ require 'test/unit'
+ require 'date'
++require 'timeout'
+ 
+ class TestDateParse < Test::Unit::TestCase
+ 
+@@ -847,6 +848,13 @@ class TestDateParse < Test::Unit::TestCase
+ 
+     h = Date._iso8601('')
+     assert_equal({}, h)
++
++    h = Date._iso8601(nil)
++    assert_equal({}, h)
++
++    h = Date._iso8601('01-02-03T04:05:06Z'.to_sym)
++    assert_equal([2001, 2, 3, 4, 5, 6, 0],
++      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+   end
+ 
+   def test__rfc3339
+@@ -862,6 +870,13 @@ class TestDateParse < Test::Unit::TestCase
+ 
+     h = Date._rfc3339('')
+     assert_equal({}, h)
++
++    h = Date._rfc3339(nil)
++    assert_equal({}, h)
++
++    h = Date._rfc3339('2001-02-03T04:05:06Z'.to_sym)
++    assert_equal([2001, 2, 3, 4, 5, 6, 0],
++      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+   end
+ 
+   def test__xmlschema
+@@ -944,6 +959,13 @@ class TestDateParse < Test::Unit::TestCase
+ 
+     h = Date._xmlschema('')
+     assert_equal({}, h)
++
++    h = Date._xmlschema(nil)
++    assert_equal({}, h)
++
++    h = Date._xmlschema('2001-02-03'.to_sym)
++    assert_equal([2001, 2, 3, nil, nil, nil, nil],
++      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+   end
+ 
+   def test__rfc2822
+@@ -976,6 +998,13 @@ class TestDateParse < Test::Unit::TestCase
+ 
+     h = Date._rfc2822('')
+     assert_equal({}, h)
++
++    h = Date._rfc2822(nil)
++    assert_equal({}, h)
++
++    h = Date._rfc2822('Sat, 3 Feb 2001 04:05:06 UT'.to_sym)
++    assert_equal([2001, 2, 3, 4, 5, 6, 0],
++      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+   end
+ 
+   def test__httpdate
+@@ -996,6 +1025,13 @@ class TestDateParse < Test::Unit::TestCase
+ 
+     h = Date._httpdate('')
+     assert_equal({}, h)
++
++    h = Date._httpdate(nil)
++    assert_equal({}, h)
++
++    h = Date._httpdate('Sat, 03 Feb 2001 04:05:06 GMT'.to_sym)
++    assert_equal([2001, 2, 3, 4, 5, 6, 0],
++      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+   end
+ 
+   def test__jisx0301
+@@ -1072,6 +1108,13 @@ class TestDateParse < Test::Unit::TestCase
+ 
+     h = Date._jisx0301('')
+     assert_equal({}, h)
++
++    h = Date._jisx0301(nil)
++    assert_equal({}, h)
++
++    h = Date._jisx0301('H13.02.03T04:05:06.07+0100'.to_sym)
++    assert_equal([2001, 2, 3, 4, 5, 6, 3600],
++      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+   end
+ 
+   def test_iso8601
+@@ -1228,4 +1271,32 @@ class TestDateParse < Test::Unit::TestCase
+     assert_equal(s0, s)
+   end
+ 
++  def test_length_limit
++    assert_raise(ArgumentError) { Date._parse("1" * 1000) }
++    assert_raise(ArgumentError) { Date._iso8601("1" * 1000) }
++    assert_raise(ArgumentError) { Date._rfc3339("1" * 1000) }
++    assert_raise(ArgumentError) { Date._xmlschema("1" * 1000) }
++    assert_raise(ArgumentError) { Date._rfc2822("1" * 1000) }
++    assert_raise(ArgumentError) { Date._rfc822("1" * 1000) }
++    assert_raise(ArgumentError) { Date._jisx0301("1" * 1000) }
++
++    assert_raise(ArgumentError) { Date.parse("1" * 1000) }
++    assert_raise(ArgumentError) { Date.iso8601("1" * 1000) }
++    assert_raise(ArgumentError) { Date.rfc3339("1" * 1000) }
++    assert_raise(ArgumentError) { Date.xmlschema("1" * 1000) }
++    assert_raise(ArgumentError) { Date.rfc2822("1" * 1000) }
++    assert_raise(ArgumentError) { Date.rfc822("1" * 1000) }
++    assert_raise(ArgumentError) { Date.jisx0301("1" * 1000) }
++
++    assert_raise(ArgumentError) { DateTime.parse("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.iso8601("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.rfc3339("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.xmlschema("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.rfc2822("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.rfc822("1" * 1000) }
++    assert_raise(ArgumentError) { DateTime.jisx0301("1" * 1000) }
++
++    assert_raise(ArgumentError) { Date._parse("Jan " + "9" * 1000000) }
++    assert_raise(Timeout::Error) { Timeout.timeout(1) { Date._parse("Jan " + "9" * 1000000, limit: nil) } }
++  end
+ end

--- a/SPECS/ruby.spec
+++ b/SPECS/ruby.spec
@@ -172,6 +172,8 @@ Patch19: ruby-2.7.1-Timeout-the-test_bug_reporter_add-witout-raising-err.patch
 # Backport CVE-2021-31810, CVE-2021-32066, and CVE-2021-31799 from
 # Ruby 2.7.4.
 Patch20: ruby-2.7.4-security-fixes.patch
+# Backport CVE-2021-41817 from date gem v3.0.2.
+Patch21: rubygems-date-cve-2021-41817.patch
 
 Requires: %{name}-libs%{?_isa} = %{version}-%{release}
 Requires: ruby(rubygems) >= %{rubygems_version}
@@ -580,6 +582,7 @@ rm -rf ext/fiddle/libffi*
 %patch13 -p1
 %patch19 -p1
 %patch20 -p1
+%patch21 -p1
 
 # Provide an example of usage of the tapset:
 cp -a %{SOURCE3} .
@@ -1131,7 +1134,7 @@ MSPECOPTS="$MSPECOPTS -P 'File.utime allows Time instances in the far future to 
 %{gem_dir}/specifications/default/benchmark-0.1.0.gemspec
 %{gem_dir}/specifications/default/cgi-0.1.0.gemspec
 %{gem_dir}/specifications/default/csv-3.1.2.gemspec
-%{gem_dir}/specifications/default/date-3.0.0.gemspec
+%{gem_dir}/specifications/default/date-3.0.2.gemspec
 %{gem_dir}/specifications/default/dbm-1.1.0.gemspec
 %{gem_dir}/specifications/default/delegate-0.1.0.gemspec
 %{gem_dir}/specifications/default/did_you_mean-%{did_you_mean_version}.gemspec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,7 @@ x-rpmbuild:
       spec_file: 'SPECS/rubygem-rack.spec'
     ruby:
       image: rpmbuild-ruby
-      version: &ruby_version '2.7.3-2'
+      version: &ruby_version '2.7.3-3'
       defines: &ruby_bundled_versions
         bundler_version: '2.1.4'
         bundler_connection_pool_version: '2.2.2'
@@ -204,16 +204,16 @@ x-rpmbuild:
         rubygems_molinillo_version: '0.5.7'
         test_unit_version: '3.3.4'
         xmlrpc_version: '0.3.0'
+      # Use the following to run the Ruby tests on a host with
+      # ZFS on Linux:
+      # with:
+      #   - zfs_host
     rubygem-pg:
       image: rpmbuild-rubygem-pg
       version: &rubygem_pg_version '1.2.3-1'
     rubygem-libxml-ruby:
       image: rpmbuild-rubygem-libxml-ruby
       version: &rubygem_libxml_ruby_version '3.2.1-1'
-    # Use the following to run the Ruby tests on a host with
-    # ZFS on Linux:
-    #  with:
-    #    - zfs_host
     sqlite:
       image: rpmbuild-sqlite
       version: &sqlite_version '3.36.0-2'


### PR DESCRIPTION
Upgrade Ruby release with `date` gem changes backported from 3.0.2 (Ruby 2.7 is frozen to 3.0.x) to address [CVE-2021-41817](http://www.ruby-lang.org/en/news/2021/11/15/date-parsing-method-regexp-dos-cve-2021-41817/).