### PR TITLE
New version of libgeotiff from Jul 05, 2021

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ x-rpmbuild:
       arch: noarch
     libgeotiff:
       image: rpmbuild-libgeotiff
-      version: &libgeotiff_version '1.6.0-1'
+      version: &libgeotiff_version '1.7.0-1'
       defines:
         proj_min_version: *proj_min_version
     libkml:


### PR DESCRIPTION
https://github.com/OSGeo/libgeotiff/releases/tag/1.7.0