### PR TITLE
New version of libosmium from Oct 05, 2021

### DIFF
--- a/SPECS/libosmium.spec
+++ b/SPECS/libosmium.spec
@@ -10,13 +10,14 @@ License:        Boost
 URL:            http://osmcode.org/libosmium/
 Source0:        https://github.com/osmcode/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 
-BuildRequires:  bzip2-devel
 BuildRequires:  boost-devel
+BuildRequires:  bzip2-devel
 BuildRequires:  cmake3
 BuildRequires:  doxygen
 BuildRequires:  expat-devel
 BuildRequires:  gcc-c++
 BuildRequires:  graphviz
+BuildRequires:  lz4-devel
 BuildRequires:  xmlstarlet
 BuildRequires:  zlib-devel
 
@@ -28,9 +29,10 @@ A fast and flexible C++ library for working with OpenStreetMap data.
 Summary:        Development files for %{name}
 BuildArch:      noarch
 
-Requires:       bzip2-devel
 Requires:       boost-devel
+Requires:       bzip2-devel
 Requires:       expat-devel
+Requires:       lz4-devel
 Requires:       protozero-devel >= %{protozero_min_version}
 Requires:       zlib-devel
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ x-rpmbuild:
       version: &libkml_version '1.3.0-1'
     libosmium:
       image: rpmbuild-libosmium
-      version: &libosmium_version '2.17.0-1'
+      version: &libosmium_version '2.17.1-1'
       arch: noarch
       name: libosmium-devel
       defines:


### PR DESCRIPTION
https://github.com/osmcode/libosmium/releases/tag/v2.17.1

There's also a newer version from Dec 16, 2021 (2.17.2) that I am having
trouble getting built, at least not without disabling unit test building 
(`-DBUILD_TESTING=OFF`), it might be related to this:
https://github.com/osmcode/libosmium/commit/a3a1974c23e68db43a44c2a5f2bd01b37015886e