### PR TITLE
New version of libosmium from Jan 19, 2022

### DIFF
--- a/SOURCES/libosmium-CentOS7GCC.patch
+++ b/SOURCES/libosmium-CentOS7GCC.patch
@@ -1,0 +1,87 @@
+commit 1b011a96081023e98d58216261c95c64c44f4624
+Author: David Hummel <6109326+hummeltech@users.noreply.github.com>
+Date:   Thu Jan 27 11:58:08 2022 -0700
+
+    Fixing build errors
+
+diff --git a/include/osmium/dynamic_handler.hpp b/include/osmium/dynamic_handler.hpp
+index 6c2a5378..df380fe4 100644
+--- a/include/osmium/dynamic_handler.hpp
++++ b/include/osmium/dynamic_handler.hpp
+@@ -130,7 +130,11 @@ auto _name_##_dispatch(THandler& handler, const osmium::_type_& object, long) ->
+                 HandlerWrapper& operator=(const HandlerWrapper&) = default;
+ 
+                 HandlerWrapper(HandlerWrapper&&) noexcept = default;
++#ifdef OSMIUM_MOVE_EXCEPT
++                HandlerWrapper& operator=(HandlerWrapper&&) = default;
++#else
+                 HandlerWrapper& operator=(HandlerWrapper&&) noexcept = default;
++#endif
+ 
+                 ~HandlerWrapper() noexcept override = default;
+ 
+diff --git a/include/osmium/index/detail/vector_map.hpp b/include/osmium/index/detail/vector_map.hpp
+index fd643144..6b830cfc 100644
+--- a/include/osmium/index/detail/vector_map.hpp
++++ b/include/osmium/index/detail/vector_map.hpp
+@@ -69,7 +69,11 @@ namespace osmium {
+                 VectorBasedDenseMap& operator=(const VectorBasedDenseMap&) = default;
+ 
+                 VectorBasedDenseMap(VectorBasedDenseMap&&) noexcept = default;
++#ifdef OSMIUM_MOVE_EXCEPT
++                VectorBasedDenseMap& operator=(VectorBasedDenseMap&&) = default;
++#else
+                 VectorBasedDenseMap& operator=(VectorBasedDenseMap&&) noexcept = default;
++#endif
+ 
+                 ~VectorBasedDenseMap() noexcept override = default;
+ 
+@@ -191,7 +195,11 @@ namespace osmium {
+                 VectorBasedSparseMap& operator=(const VectorBasedSparseMap&) = default;
+ 
+                 VectorBasedSparseMap(VectorBasedSparseMap&&) noexcept = default;
++#ifdef OSMIUM_MOVE_EXCEPT
++                VectorBasedSparseMap& operator=(VectorBasedSparseMap&&) = default;
++#else
+                 VectorBasedSparseMap& operator=(VectorBasedSparseMap&&) noexcept = default;
++#endif
+ 
+                 ~VectorBasedSparseMap() noexcept override = default;
+ 
+diff --git a/include/osmium/index/detail/vector_multimap.hpp b/include/osmium/index/detail/vector_multimap.hpp
+index 3b479620..08f8bec3 100644
+--- a/include/osmium/index/detail/vector_multimap.hpp
++++ b/include/osmium/index/detail/vector_multimap.hpp
+@@ -79,7 +79,11 @@ namespace osmium {
+                 VectorBasedSparseMultimap& operator=(const VectorBasedSparseMultimap&) = default;
+ 
+                 VectorBasedSparseMultimap(VectorBasedSparseMultimap&&) noexcept = default;
++#ifdef OSMIUM_MOVE_EXCEPT
++                VectorBasedSparseMultimap& operator=(VectorBasedSparseMultimap&&) = default;
++#else
+                 VectorBasedSparseMultimap& operator=(VectorBasedSparseMultimap&&) noexcept = default;
++#endif
+ 
+                 ~VectorBasedSparseMultimap() noexcept override = default;
+ 
+diff --git a/include/osmium/util/compatibility.hpp b/include/osmium/util/compatibility.hpp
+index bce554fb..617bbd15 100644
+--- a/include/osmium/util/compatibility.hpp
++++ b/include/osmium/util/compatibility.hpp
+@@ -33,6 +33,16 @@ DEALINGS IN THE SOFTWARE.
+ 
+ */
+ 
++// Workaround for GNU where the move assignment operator declaration does not
++// match the exception-specification of the implicit declaration.
++#ifdef __GNUC__
++# if __GNUC__ <= 4
++#  if __GNUC_MINOR__ <= 8
++#   define OSMIUM_MOVE_EXCEPT
++#  endif
++# endif
++#endif
++
+ // Workarounds for MSVC which doesn't support [[noreturn]]
+ // This is not needed any more, but kept here for the time being, because
+ // older versions of osmium-tool need it.

--- a/SPECS/libosmium.spec
+++ b/SPECS/libosmium.spec
@@ -10,6 +10,8 @@ License:        Boost
 URL:            http://osmcode.org/libosmium/
 Source0:        https://github.com/osmcode/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 
+Patch0:         libosmium-CentOS7GCC.patch
+
 BuildRequires:  boost-devel
 BuildRequires:  bzip2-devel
 BuildRequires:  cmake3
@@ -52,7 +54,6 @@ pushd build
 %cmake3 \
   -DBUILD_EXAMPLES=OFF \
   -DBUILD_HEADERS=OFF \
-  -DBUILD_TESTING=OFF \
   -DINSTALL_GDALCPP=ON \
   ..
 %cmake3_build

--- a/SPECS/libosmium.spec
+++ b/SPECS/libosmium.spec
@@ -10,13 +10,14 @@ License:        Boost
 URL:            http://osmcode.org/libosmium/
 Source0:        https://github.com/osmcode/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 
-BuildRequires:  bzip2-devel
 BuildRequires:  boost-devel
+BuildRequires:  bzip2-devel
 BuildRequires:  cmake3
 BuildRequires:  doxygen
 BuildRequires:  expat-devel
 BuildRequires:  gcc-c++
 BuildRequires:  graphviz
+BuildRequires:  lz4-devel
 BuildRequires:  xmlstarlet
 BuildRequires:  zlib-devel
 
@@ -28,9 +29,10 @@ A fast and flexible C++ library for working with OpenStreetMap data.
 Summary:        Development files for %{name}
 BuildArch:      noarch
 
-Requires:       bzip2-devel
 Requires:       boost-devel
+Requires:       bzip2-devel
 Requires:       expat-devel
+Requires:       lz4-devel
 Requires:       protozero-devel >= %{protozero_min_version}
 Requires:       zlib-devel
 
@@ -47,7 +49,12 @@ developing applications that use %{name}.
 
 %build
 pushd build
-%cmake3 -DBUILD_EXAMPLES=OFF -DBUILD_HEADERS=OFF -DINSTALL_GDALCPP=ON ..
+%cmake3 \
+  -DBUILD_EXAMPLES=OFF \
+  -DBUILD_HEADERS=OFF \
+  -DBUILD_TESTING=OFF \
+  -DINSTALL_GDALCPP=ON \
+  ..
 %cmake3_build
 popd
 

--- a/SPECS/libosmium.spec
+++ b/SPECS/libosmium.spec
@@ -18,8 +18,14 @@ BuildRequires:  cmake3
 BuildRequires:  doxygen
 BuildRequires:  expat-devel
 BuildRequires:  gcc-c++
+BuildRequires:  gdal-devel
+BuildRequires:  geos-devel
 BuildRequires:  graphviz
 BuildRequires:  lz4-devel
+BuildRequires:  protozero-devel >= %{protozero_min_version}
+BuildRequires:  ruby
+BuildRequires:  rubygem-json
+BuildRequires:  sparsehash-devel
 BuildRequires:  xmlstarlet
 BuildRequires:  zlib-devel
 
@@ -52,7 +58,6 @@ developing applications that use %{name}.
 %build
 pushd build
 %cmake3 \
-  -DBUILD_EXAMPLES=OFF \
   -DBUILD_HEADERS=OFF \
   -DINSTALL_GDALCPP=ON \
   ..

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ x-rpmbuild:
       version: &libkml_version '1.3.0-1'
     libosmium:
       image: rpmbuild-libosmium
-      version: &libosmium_version '2.17.2-1'
+      version: &libosmium_version '2.17.3-1'
       arch: noarch
       name: libosmium-devel
       defines:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ x-rpmbuild:
       version: &libkml_version '1.3.0-1'
     libosmium:
       image: rpmbuild-libosmium
-      version: &libosmium_version '2.17.0-1'
+      version: &libosmium_version '2.17.2-1'
       arch: noarch
       name: libosmium-devel
       defines:


### PR DESCRIPTION
https://github.com/osmcode/libosmium/releases/tag/v2.17.3

Also:
* Added `BuildRequires` & removed `BUILD_EXAMPLES=OFF`
  * To support more test cases (the produced `RPM` does not contain any additional files)

    Before:
    ```
    100% tests passed, 0 tests failed out of 86
    ```
    
    After:
    ```
    100% tests passed, 0 tests failed out of 159
    ```
* Added a [patch](https://github.com/radiant-maxar/geoint-deps/blob/libosmium_2.17.2/SOURCES/libosmium-CentOS7GCC.patch) which seems to fix the issue which I believe was introduced [here](https://github.com/osmcode/libosmium/commit/0af04dcf3276a8016edfde08a1d064751b309ae5#diff-75752c7c82bf99404ff83c5016d94292b127f1ff634f4d556d7da4814fa50779).