### PR TITLE
Fixed issue preventing `default` map layer from loading

### DIFF
--- a/SPECS/openstreetmap-carto.spec
+++ b/SPECS/openstreetmap-carto.spec
@@ -244,7 +244,7 @@ lua scripts/lua/test.lua
 %{__install} -d %{buildroot}%{openstreetmap_carto_home}/scripts
 %{__cp} --preserve scripts/*.py %{buildroot}%{openstreetmap_carto_home}/scripts
 %{__cp} --recursive --preserve scripts/lua %{buildroot}%{openstreetmap_carto_home}/scripts
-%{__cp} --recursive --preserve style symbols %{buildroot}%{openstreetmap_carto_home}
+%{__cp} --recursive --preserve patterns style symbols %{buildroot}%{openstreetmap_carto_home}
 %{__cp} --preserve indexes.* openstreetmap-carto.* road-colors.yaml %{buildroot}%{openstreetmap_carto_home}
 
 %{__ln_s} %{openstreetmap_carto_data}/data %{buildroot}%{openstreetmap_carto_home}
@@ -252,6 +252,7 @@ lua scripts/lua/test.lua
 %{__install} -d %{buildroot}%{openstreetmap_carto_sysconf}
 %{__cp} --preserve project.mml external-data.yml %{buildroot}%{openstreetmap_carto_sysconf}
 %{__ln_s} %{openstreetmap_carto_sysconf}/external-data.yml %{buildroot}%{openstreetmap_carto_home}
+%{__ln_s} %{openstreetmap_carto_home}/patterns %{buildroot}%{openstreetmap_carto_sysconf}
 %{__ln_s} %{openstreetmap_carto_home}/style %{buildroot}%{openstreetmap_carto_sysconf}
 %{__ln_s} %{openstreetmap_carto_home}/symbols %{buildroot}%{openstreetmap_carto_sysconf}
 
@@ -261,6 +262,7 @@ lua scripts/lua/test.lua
 %license LICENSE.txt
 %{openstreetmap_carto_home}/*
 %dir %{openstreetmap_carto_sysconf}
+%{openstreetmap_carto_sysconf}/patterns
 %{openstreetmap_carto_sysconf}/style
 %{openstreetmap_carto_sysconf}/symbols
 %config(noreplace) %{openstreetmap_carto_sysconf}/project.mml


### PR DESCRIPTION
Caused by missing files, I.E.:
```
** (process:104): ERROR **: 01:07:35.553: An error occurred while loading the map layer 'default': file could not be found: '/etc/openstreetmap-carto/patterns/grave_yard_jewish.svg' in style 'landcover-high-zoom' in PolygonPatternSymbolizer at line 1669 of '/etc/openstreetmap-carto/tile-backend.xml'
```
A new directory containing reusable `patterns` was added.
https://github.com/gravitystorm/openstreetmap-carto/compare/v5.3.1...v5.4.0

After including that directory:
![image](https://user-images.githubusercontent.com/6109326/150606874-e5c0ee5d-49bc-4236-a082-3a88a42283c7.png)

![image](https://user-images.githubusercontent.com/6109326/150606785-df76ab98-d392-4fa7-819d-04e12148b359.png)

