### PR TITLE
PostGIS 3.2.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ x-rpmbuild:
       version: &passenger_version '6.0.12-1'
     postgis:
       image: rpmbuild-postgis
-      version: &postgis_version '3.1.4-1'
+      version: &postgis_version '3.2.1-1'
       defines:
         gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version


### PR DESCRIPTION
Brings us to the latest in the new [3.2.x](https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.2.0/NEWS) release line.  Changelog review and initial testing gives me confidence this is an incremental enhancement and shouldn't introduce breaking changes to downstream users.  Signed release available in the `testing` channel.