### PR TITLE
Ruby 2.7.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,7 @@ x-rpmbuild:
       spec_file: 'SPECS/rubygem-rack.spec'
     ruby:
       image: rpmbuild-ruby
-      version: &ruby_version '2.7.5-1'
+      version: &ruby_version '2.7.6-1'
       defines: &ruby_bundled_versions
         bundler_version: '2.1.4'
         bundler_connection_pool_version: '2.2.2'


### PR DESCRIPTION
Upgrade Ruby to [2.7.6](https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-7-6-released/).