### PR TITLE
Rack 2.2.3.1

### DIFF
--- a/SPECS/rubygem-rack.spec
+++ b/SPECS/rubygem-rack.spec
@@ -27,17 +27,10 @@ BuildRequires: ruby
 BuildRequires: ruby-devel
 BuildRequires: rubygems-devel
 %if %{with tests}
-BuildRequires: fcgi
-BuildRequires: fcgi-devel
-BuildRequires: lighttpd-fastcgi
 BuildRequires: memcached
 BuildRequires: rubygem-memcache-client
-# Testing requires thin, which has a circular dependency with Rack;
-# get all from RubyGems.
-#BuildRequires: rubygem-rack
 #BuildRequires: rubygem(minitest)
-#BuildRequires: rubygem(fcgi)
-#BuildRequires: rubygem(thin)
+#BuildRequires: rubygem(webrick)
 %endif
 
 BuildArch: noarch
@@ -102,6 +95,10 @@ pushd .%{gem_instdir}
 # on usual environment.
 # The server status does not return ":not_owned".
 sed -i '/^  it "check pid file presence and not owned process" do$/,/^  end$/ s/^/#/' \
+  test/spec_server.rb
+
+# Test wasn't updated for 2.2.3.1 security release.
+sed -i '/^  it "support -v option to get version" do$/,/^  end$/ s/^/#/' \
   test/spec_server.rb
 
 # Get temporary PID file name and start memcached daemon.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,10 +178,10 @@ x-rpmbuild:
         pybind11_version: '2.7.1'
     rack:
       image: rpmbuild-rack
-      version: &rack_version '2.2.3-1'
+      version: &rack_version 2.2.3.1-1
       arch: noarch
       name: rubygem-rack
-      spec_file: 'SPECS/rubygem-rack.spec'
+      spec_file: SPECS/rubygem-rack.spec
     ruby:
       image: rpmbuild-ruby
       version: &ruby_version '2.7.6-1'
@@ -595,11 +595,10 @@ services:
       <<: *build_defaults
       args:
         gem_packages: >-
-          fcgi
           minitest
           minitest-sprint
           minitest-global_expectations
-          thin
+          webrick
         packages: "${RPMBUILD_RACK_PACKAGES}"
         rpmbuild_channel: *rpmbuild_channel
       dockerfile: docker/Dockerfile.rpmbuild-geoint-deps


### PR DESCRIPTION
* Upgrade Rack to 2.2.3.1; fixes CVE-2022-30122 and CVE-2022-30123.
* Clean up Rack's build requirements.