### PR TITLE
Upgrade Passenger to 6.0.14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ x-rpmbuild:
         protobuf_c_min_version: *protobuf_c_min_version
     passenger:
       image: rpmbuild-passenger
-      version: &passenger_version '6.0.13-1'
+      version: &passenger_version 6.0.14-1
     postgis:
       image: rpmbuild-postgis
       version: &postgis_version '3.2.1-1'


### PR DESCRIPTION
Only thing of note in the [CHANGELOG](https://github.com/phusion/passenger/blob/stable-6.0/CHANGELOG):
> Fixes a use after free regression introduced in 6.0.12.