### PR TITLE
GDAL 3.2.3-2

### DIFF
--- a/SPECS/gdal.spec
+++ b/SPECS/gdal.spec
@@ -591,6 +591,7 @@ pushd gdalautotest-%{testversion}
   # Run tests with problematic cases deselected.  Some possible explanations:
   #  * gcore/tiff_read.py: will eventually pass, but consumes all memory
   #      forcing host to swap.
+  #  * gcore/vsi{curl,s3}: Old test links have gone stale.
   #  * gdrivers/gdalhttp.py: test_http_4 takes way too long
   #  * gdrivers/pdf.py: disabled tests cause segfaults on EL platforms;
   #      most likely due to old poppler library
@@ -604,6 +605,8 @@ pushd gdalautotest-%{testversion}
     --deselect gcore/tiff_read.py::test_tiff_read_toomanyblocks \
     --deselect gcore/tiff_read.py::test_tiff_read_toomanyblocks_separate \
     --deselect gcore/tiff_write.py::test_tiff_write_87 \
+    --deselect gcore/vsicurl.py::test_vsicurl_test_redirect \
+    --deselect gcore/vsis3.py::test_vsis3_no_sign_request \
     --deselect gdrivers/gdalhttp.py::test_http_4 \
     --deselect gdrivers/pdf.py::test_pdf_jp2_auto_compression \
     --deselect gdrivers/pdf.py::test_pdf_jp2openjpeg_compression \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ x-rpmbuild:
       version: '1.2.5-1'
     gdal:
       image: rpmbuild-gdal
-      version: &gdal_version '3.2.3-1'
+      version: &gdal_version 3.2.3-2
       defines:
         geos_min_version: *geos_min_version
         proj_min_version: *proj_min_version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ x-rpmbuild:
       arch: noarch
     libgeotiff:
       image: rpmbuild-libgeotiff
-      version: &libgeotiff_version '1.6.0-1'
+      version: &libgeotiff_version 1.7.1-1
       defines:
         proj_min_version: *proj_min_version
     journald-cloudwatch-logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ x-rpmbuild:
         proj_min_version: *proj_min_version
     geos:
       image: rpmbuild-geos
-      version: &geos_version '3.9.2-1'
+      version: &geos_version 3.9.3-1
     gpsbabel:
       image: rpmbuild-gpsbabel
       version: &gpsbabel_version '1.7.0-1'

--- a/docker/Dockerfile.rpmbuild-gdal
+++ b/docker/Dockerfile.rpmbuild-gdal
@@ -62,7 +62,8 @@ RUN --mount=type=cache,target=/var/cache/yum \
     /tmp/sqlite-devel-${sqlite_version}${RPMBUILD_DIST}.x86_64.rpm \
     && \
     rm -f /tmp/*.rpm && \
-    if [ -n "${packages}" ] ; then yum -y install ${packages}; fi
+    if [ -n "${packages}" ] ; then yum -y install ${packages}; fi && \
+    chown -R ${RPMBUILD_USER}:${RPMBUILD_GROUP} /var/run/postgresql
 
 # Install Python 3 documentation and packages.
 RUN pip3 install --disable-pip-version-check --require-hashes \


### PR DESCRIPTION
* A new GDAL release is necessary to use the latest version of Armadillo in EPEL.  Version 8 was replaced with version 10 in EPEL, with the end result being our `gdal-3.2.3-1` release can no longer be installed.
* Upgrade GEOS to [3.9.3](https://github.com/libgeos/geos/blob/3.9.3/NEWS), a bugfix release.
* Upgrade libgeotiff to [1.7.1](https://github.com/OSGeo/libgeotiff/releases/tag/1.7.1); see also @hummeltech's work in #17, recompiling GDAL allowed for full testing with the updated library.