### PR TITLE
Fix OGDI is missing

### DIFF
--- a/SPECS/gdal.spec
+++ b/SPECS/gdal.spec
@@ -164,6 +164,7 @@ This package contains development files for GDAL.
 
 %package libs
 Summary:	GDAL file format library
+Requires:	ogdi
 
 %description libs
 This package contains the GDAL file format library.

--- a/SPECS/mapnik.spec
+++ b/SPECS/mapnik.spec
@@ -162,6 +162,7 @@ local_optflags="%{optflags}"
 local_optflags="${local_optflags} -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H"
 
 # configure mapnik
+export JOBS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
 PROJ_LIB=%{_datadir}/proj \
 GDAL_DATA=$(gdal-config --datadir) \
 scons configure FAST=True \

--- a/SPECS/mapnik.spec
+++ b/SPECS/mapnik.spec
@@ -162,7 +162,6 @@ local_optflags="%{optflags}"
 local_optflags="${local_optflags} -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H"
 
 # configure mapnik
-export JOBS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
 PROJ_LIB=%{_datadir}/proj \
 GDAL_DATA=$(gdal-config --datadir) \
 scons configure FAST=True \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -409,6 +409,7 @@ services:
         gpsbabel_version: *gpsbabel_version
         libgeotiff_version: *libgeotiff_version
         libkml_version: *libkml_version
+        ogdi_version: *ogdi_version
         packages: "${RPMBUILD_MAPNIK_PACKAGES}"
         postgis_version: *postgis_version
         proj_version: *proj_version
@@ -488,6 +489,7 @@ services:
         libgeotiff_version: *libgeotiff_version
         libkml_version: *libkml_version
         libosmium_version: *libosmium_version
+        ogdi_version: *ogdi_version
         packages: "${RPMBUILD_OSM2PGSQL_PACKAGES}"
         postgis_version: *postgis_version
         proj_version: *proj_version
@@ -533,6 +535,7 @@ services:
         gpsbabel_version: *gpsbabel_version
         libgeotiff_version: *libgeotiff_version
         libkml_version: *libkml_version
+        ogdi_version: *ogdi_version
         packages: "${RPMBUILD_POSTGIS_PACKAGES}"
         proj_version: *proj_version
         protobuf_version: *protobuf_version
@@ -581,6 +584,7 @@ services:
         libgeotiff_version: *libgeotiff_version
         libkml_version: *libkml_version
         mapnik_version: *mapnik_version
+        ogdi_version: *ogdi_version
         packages: "${RPMBUILD_PYTHON_MAPNIK_PACKAGES}"
         postgis_version: *postgis_version
         proj_version: *proj_version

--- a/docker/Dockerfile.rpmbuild-mapnik-generic
+++ b/docker/Dockerfile.rpmbuild-mapnik-generic
@@ -10,6 +10,7 @@ ARG gpsbabel_version
 ARG libgeotiff_version
 ARG libkml_version
 ARG mapnik_version
+ARG ogdi_version
 ARG packages
 ARG postgis_version
 ARG proj_version
@@ -41,6 +42,8 @@ COPY RPMS/x86_64/CGAL-${cgal_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/mapnik-devel-${mapnik_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/mapnik-static-${mapnik_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/mapnik-utils-${mapnik_version}${RPMBUILD_DIST}.x86_64.rpm \
+     RPMS/x86_64/ogdi-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
+     RPMS/x86_64/ogdi-devel-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/postgis-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
@@ -78,6 +81,8 @@ RUN --mount=type=cache,target=/var/cache/yum \
     /tmp/mapnik-devel-${mapnik_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/mapnik-static-${mapnik_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/mapnik-utils-${mapnik_version}${RPMBUILD_DIST}.x86_64.rpm \
+    /tmp/ogdi-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
+    /tmp/ogdi-devel-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/postgis-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \

--- a/docker/Dockerfile.rpmbuild-osm2pgsql
+++ b/docker/Dockerfile.rpmbuild-osm2pgsql
@@ -10,6 +10,7 @@ ARG gpsbabel_version
 ARG libgeotiff_version
 ARG libkml_version
 ARG libosmium_version
+ARG ogdi_version
 ARG packages
 ARG postgis_version
 ARG proj_version
@@ -38,6 +39,8 @@ COPY RPMS/x86_64/CGAL-${cgal_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libkml-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libkml-devel-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/noarch/libosmium-devel-${libosmium_version}${RPMBUILD_DIST}.noarch.rpm \
+     RPMS/x86_64/ogdi-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
+     RPMS/x86_64/ogdi-devel-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/postgis-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
@@ -73,6 +76,8 @@ RUN --mount=type=cache,target=/var/cache/yum \
     /tmp/libkml-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/libkml-devel-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/libosmium-devel-${libosmium_version}${RPMBUILD_DIST}.noarch.rpm \
+    /tmp/ogdi-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
+    /tmp/ogdi-devel-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/postgis-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \

--- a/docker/Dockerfile.rpmbuild-postgis
+++ b/docker/Dockerfile.rpmbuild-postgis
@@ -9,6 +9,7 @@ ARG geos_version
 ARG gpsbabel_version
 ARG libgeotiff_version
 ARG libkml_version
+ARG ogdi_version
 ARG packages
 ARG proj_version
 ARG protobuf_version
@@ -35,6 +36,8 @@ COPY RPMS/x86_64/CGAL-${cgal_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libgeotiff-devel-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libkml-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libkml-devel-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
+     RPMS/x86_64/ogdi-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
+     RPMS/x86_64/ogdi-devel-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/protobuf-${protobuf_version}${RPMBUILD_DIST}.x86_64.rpm \
@@ -65,6 +68,8 @@ RUN --mount=type=cache,target=/var/cache/yum \
     /tmp/libgeotiff-devel-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/libkml-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/libkml-devel-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
+    /tmp/ogdi-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
+    /tmp/ogdi-devel-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/protobuf-${protobuf_version}${RPMBUILD_DIST}.x86_64.rpm \

--- a/docker/Dockerfile.rpmbuild-postgis-generic
+++ b/docker/Dockerfile.rpmbuild-postgis-generic
@@ -9,6 +9,7 @@ ARG geos_version
 ARG gpsbabel_version
 ARG libgeotiff_version
 ARG libkml_version
+ARG ogdi_version
 ARG packages
 ARG postgis_version
 ARG proj_version
@@ -36,6 +37,8 @@ COPY RPMS/x86_64/CGAL-${cgal_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libgeotiff-devel-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libkml-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libkml-devel-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
+     RPMS/x86_64/ogdi-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
+     RPMS/x86_64/ogdi-devel-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/postgis-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
@@ -69,6 +72,8 @@ RUN --mount=type=cache,target=/var/cache/yum \
     /tmp/libgeotiff-devel-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/libkml-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/libkml-devel-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
+    /tmp/ogdi-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
+    /tmp/ogdi-devel-${ogdi_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/postgis-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \


### PR DESCRIPTION
`gdal-libs` requires `libogdi.so.4()(64bit)`
I.E.:
```
Provides: gdal-libs = 3.2.3-3.el7 gdal-libs(x86-64) = 3.2.3-3.el7 libgdal.so.28()(64bit)
Requires(interp): /sbin/ldconfig /sbin/ldconfig
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires(post): /sbin/ldconfig
Requires(postun): /sbin/ldconfig
Requires: ld-linux-x86-64.so.2()(64bit) ld-linux-x86-64.so.2(GLIBC_2.3)(64bit) libFileGDBAPI.so()(64bit) libSFCGAL.so.1()(64bit) libarmadillo.so.10()(64bit) libc.so.6()(64bit) libc.so.6(GLIBC_2.11)(64bit) libc.so.6(GLIBC_2.14)(64bit) libc.so.6(GLIBC_2.15)(64bit) libc.so.6(GLIBC_2.2.5)(64bit) libc.so.6(GLIBC_2.3)(64bit) libc.so.6(GLIBC_2.3.4)(64bit) libc.so.6(GLIBC_2.4)(64bit) libc.so.6(GLIBC_2.7)(64bit) libcfitsio.so.2()(64bit) libcurl.so.4()(64bit) libdap.so.17()(64bit) libdapclient.so.6()(64bit) libdapserver.so.7()(64bit) libdl.so.2()(64bit) libdl.so.2(GLIBC_2.2.5)(64bit) libexpat.so.1()(64bit) libfgdbunixrtl.so()(64bit) libfreexl.so.1()(64bit) libgcc_s.so.1()(64bit) libgcc_s.so.1(GCC_3.0)(64bit) libgcc_s.so.1(GCC_4.2.0)(64bit) libgeos_c.so.1()(64bit) libgeotiff.so.5()(64bit) libgif.so.4()(64bit) libgta.so.0()(64bit) libhdf5.so.8()(64bit) libjasper.so.1()(64bit) libjpeg.so.62()(64bit) libjpeg.so.62(LIBJPEG_6.2)(64bit) libjson-c.so.2()(64bit) libkmlbase.so.1()(64bit) libkmldom.so.1()(64bit) libkmlengine.so.1()(64bit) libkmlregionator.so.1()(64bit) libkmlxsd.so.1()(64bit) liblzma.so.5()(64bit) libm.so.6()(64bit) libm.so.6(GLIBC_2.2.5)(64bit) libnetcdf.so.7()(64bit) libodbc.so.2()(64bit) libodbcinst.so.2()(64bit) libogdi.so.4()(64bit) libopenjp2.so.7()(64bit) libpcre.so.1()(64bit) libpng15.so.15()(64bit) libpng15.so.15(PNG15_0)(64bit) libpoppler.so.46()(64bit) libpq.so.5()(64bit) libproj.so.19()(64bit) libpthread.so.0()(64bit) libpthread.so.0(GLIBC_2.2.5)(64bit) libpthread.so.0(GLIBC_2.3.2)(64bit) librt.so.1()(64bit) libsqlite3.so.0()(64bit) libstdc++.so.6()(64bit) libstdc++.so.6(CXXABI_1.3)(64bit) libstdc++.so.6(CXXABI_1.3.5)(64bit) libstdc++.so.6(CXXABI_1.3.7)(64bit) libstdc++.so.6(GLIBCXX_3.4)(64bit) libstdc++.so.6(GLIBCXX_3.4.11)(64bit) libstdc++.so.6(GLIBCXX_3.4.14)(64bit) libstdc++.so.6(GLIBCXX_3.4.15)(64bit) libstdc++.so.6(GLIBCXX_3.4.17)(64bit) libstdc++.so.6(GLIBCXX_3.4.18)(64bit) libstdc++.so.6(GLIBCXX_3.4.9)(64bit) libtiff.so.5()(64bit) libtiff.so.5(LIBTIFF_4.0)(64bit) libwebp.so.4()(64bit) libxerces-c-3.1.so()(64bit) libxml2.so.2()(64bit) libz.so.1()(64bit) libz.so.1(ZLIB_1.2.0)(64bit) libz.so.1(ZLIB_1.2.2)(64bit) libzstd.so.1()(64bit) rtld(GNU_HASH)
```