### PR TITLE
Greatly speed up `google-noto-fonts-extra` by using pre-built fonts

### DIFF
--- a/SPECS/google-noto-fonts-extra.spec
+++ b/SPECS/google-noto-fonts-extra.spec
@@ -4,14 +4,10 @@ Release:        %{rpmbuild_release}%{?dist}
 Summary:        Beautiful and free fonts for all languages
 
 License:        OFL 1.1
-URL:            https://github.com/googlefonts/noto-source
-Source0:        https://github.com/googlefonts/noto-source/archive/%{commit}/noto-source-%{commit}.tar.gz
+URL:            https://github.com/notofonts/noto-fonts
+Source0:        https://github.com/notofonts/noto-fonts/archive/%{commit}/noto-fonts-%{commit}.tar.gz
 
 BuildArch:      noarch
-
-BuildRequires:  git
-BuildRequires:  python3
-BuildRequires:  python3-pip
 
 
 %description
@@ -27,38 +23,29 @@ weights, and is freely available to all.
 
 
 %prep
-%autosetup -p 1 -n noto-source-%{commit}
-%{__sed} -i 's#git submodule update --init##g' ./build
-%{__sed} -i 's#pip install -r scripts/fontmake/requirements.txt##g' ./build
-%{__sed} -i 's#pip install -e scripts/fontmake#pip install fontmake#g' ./build
-./build setup
+%autosetup -n noto-fonts-%{commit}
 
 
 %build
-# Only build .ttf files to save time
-%{__sed} -i "s#'otf' 'ttf'#'ttf'#g" ./build
-# ./build all
-./build src/NotoSansAdlam/NotoSansAdlam.designspace
-./build src/NotoSansAdlamUnjoined/NotoSansAdlamUnjoined.designspace
-./build src/NotoSansArabicUI-MM.glyphs
-./build src/NotoSansChakma/NotoSansChakma.glyphs
-./build src/NotoSansCherokee/NotoSansCherokee.designspace
-./build src/NotoSansOriyaUI-MM.glyphs
-./build src/NotoSansOsage/NotoSansOsage.glyphs
-./build src/NotoSansSinhala/NotoSansSinhala-MM.glyphs
-./build src/NotoSansSymbols/NotoSansSymbols.designspace
-./build src/NotoSansSymbols2/NotoSansSymbols2.designspace
-./build src/NotoSerifTibetan-MM.glyphs
 
 
 %install
 %{__install} -d -p %{buildroot}%{_datadir}/fonts/%{name}
-%{__cp} --preserve instance_ttf/* %{buildroot}%{_datadir}/fonts/%{name}
-
+%{__install} -p hinted/ttf/NotoSansAdlam/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSansAdlamUnjoined/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSansArabicUI/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSansChakma/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSansCherokee/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSansOriyaUI/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSansOsage/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSansSinhala/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSansSymbols/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSansSymbols2/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
+%{__install} -p hinted/ttf/NotoSerifTibetan/*.ttf %{buildroot}%{_datadir}/fonts/%{name}/
 
 %files
-%doc README.md CONTRIBUTING.md FONT_CONTRIBUTION.md
-%license src/LICENSE
+%doc README.md FAQ.md FAQ-KR.md NEWS.md
+%license LICENSE
 %{_datadir}/fonts/%{name}
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,9 +60,9 @@ x-rpmbuild:
       version: &gpsbabel_version '1.7.0-1'
     google-noto-fonts-extra:
       image: rpmbuild-fonts
-      version: &google-noto-fonts-extra_version '20210210-1'
+      version: &google-noto-fonts-extra_version '20220418-1'
       defines:
-        commit: '0c0b4f8660099c9cda5db230f9ce38733089a2a9'
+        commit: '523a250c35d417c217c580f0743e41d8ca4b7657'
       arch: noarch
     hanazono-fonts:
       image: rpmbuild-fonts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,7 +167,7 @@ x-rpmbuild:
         protobuf_min_version: *protobuf_min_version
     python-mapnik:
       image: rpmbuild-python-mapnik
-      version: &python-mapnik_version 3.0.23 -1
+      version: &python-mapnik_version 3.0.23-1
       defines:
         # Have to specify git commit, project doesn't consistently use tags.
         commit: 7da019cf9eb12af8f8aa88b7d75789dfcd1e901b


### PR DESCRIPTION
I was actually thinking of renaming this to `google-noto-fonts` and including all of the fonts from the `hinted/ttf` directory. Then we could install all of the noto fonts in one go:
https://github.com/radiant-maxar/geoint-deps/blob/stable/SPECS/openstreetmap-carto.spec#L41-L156