### PR TITLE
Fixed cherry-pick mix-up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ x-rpmbuild:
     protobuf-c: &protobuf_c_min_version 1.3.0
     protozero: &protozero_min_version 1.7.0
     sqlite_min_version: &sqlite_min_version 3.11.0
-  # Configuration for building every dlependency RPM.
+  # Configuration for building every dependency RPM.
   rpms:
     CGAL:
       image: rpmbuild-cgal
@@ -103,7 +103,7 @@ x-rpmbuild:
       version: &libpqxx_version 7.7.3-1
     libkml:
       image: rpmbuild-libkml
-      version: &libkml_version  1.3.0-1
+      version: &libkml_version 1.3.0-1
     libosmium:
       image: rpmbuild-libosmium
       version: &libosmium_version 2.18.0-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,9 +72,9 @@ x-rpmbuild:
       version: &gpsbabel_version 1.8.0-1
     google-noto-fonts-extra:
       image: rpmbuild-fonts
-      version: &google-noto-fonts-extra_version 20210210-1
+      version: &google-noto-fonts-extra_version 20220418-1
       defines:
-        commit: 0c0b4f8660099c9cda5db230f9ce38733089a2a9
+        commit: 523a250c35d417c217c580f0743e41d8ca4b7657
       arch: noarch
     g2clib:
       image: rpmbuild-g2clib


### PR DESCRIPTION
`google-noto-fonts-extra` changes in `docker-compose.yml` were accidentally overwritten in [9910a0e5ab7c0d717533547dec3cb0f340c3c745](https://github.com/radiant-maxar/geoint-deps/commit/9910a0e5ab7c0d717533547dec3cb0f340c3c745#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L73-L78)

Fixed typo and extraneous space