### PR TITLE
Enable automatic pushing of built RPMs to S3

### DIFF
--- a/.github/workflows/ci.el7.yml
+++ b/.github/workflows/ci.el7.yml
@@ -188,9 +188,9 @@ jobs:
         with:
           el_version: ${{ env.EL_VERSION }}
 
-      # - name: Upload repository
-      #   uses: ./.github/actions/repository/upload
-      #   with:
-      #     aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     el_version: ${{ env.EL_VERSION }}
+      - name: Upload repository
+        uses: ./.github/actions/repository/upload
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          el_version: ${{ env.EL_VERSION }}

--- a/.github/workflows/ci.el9.yml
+++ b/.github/workflows/ci.el9.yml
@@ -167,9 +167,9 @@ jobs:
         with:
           el_version: ${{ env.EL_VERSION }}
 
-      # - name: Upload repository
-      #   uses: ./.github/actions/repository/upload
-      #   with:
-      #     aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     el_version: ${{ env.EL_VERSION }}
+      - name: Upload repository
+        uses: ./.github/actions/repository/upload
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          el_version: ${{ env.EL_VERSION }}


### PR DESCRIPTION
S3 prefix is based on the branch name
Only for branches other than `stable`