### PR TITLE
Make "Create repository" bash pathname expansion pattern less specific

### DIFF
--- a/.github/actions/repository/create/action.yml
+++ b/.github/actions/repository/create/action.yml
@@ -44,7 +44,7 @@ runs:
       run: >-
         make rpmbuild-generic &&
         mkdir --parents ${REPO_DIR} &&
-        cp --verbose ${{ inputs.rpms_dir }}/{noarch,x86_64}/*.rpm ${REPO_DIR}/ &&
+        cp --verbose ${{ inputs.rpms_dir }}/*/*.rpm ${REPO_DIR}/ &&
         docker-compose run -v ${REPO_DIR}:${REPO_DIR}:rw -v ${PWD}/scripts:/rpmbuild/scripts:ro -T rpmbuild-generic bash -c "
           scripts/repo-update.sh ${REPO_DIR}
         "


### PR DESCRIPTION
To prevent issues such as this where only RPMs for x86_64 exist:
```
cp: cannot stat 'RPMS/noarch/*.rpm': No such file or directory
```