### PR TITLE
Add patch for wal-g to work on PostgreSQL 15

### DIFF
--- a/SOURCES/el9/wal-g-postgresql15.patch
+++ b/SOURCES/el9/wal-g-postgresql15.patch
@@ -1,0 +1,24 @@
+diff --git a/internal/databases/postgres/queryRunner.go b/internal/databases/postgres/queryRunner.go
+index 69256d60..2e3831eb 100644
+--- a/internal/databases/postgres/queryRunner.go
++++ b/internal/databases/postgres/queryRunner.go
+@@ -102,6 +102,10 @@ func (queryRunner *PgQueryRunner) BuildStartBackup() (string, error) {
+ 	// TODO: rewrite queries for older versions to remove pg_is_in_recovery()
+ 	// where pg_start_backup() will fail on standby anyway
+ 	switch {
++	case queryRunner.Version >= 150000:
++		return "SELECT case when pg_is_in_recovery()" +
++			" then '' else (pg_walfile_name_offset(lsn)).file_name end, lsn::text, pg_is_in_recovery()" +
++			" FROM pg_backup_start($1, true) lsn", nil
+ 	case queryRunner.Version >= 100000:
+ 		return "SELECT case when pg_is_in_recovery()" +
+ 			" then '' else (pg_walfile_name_offset(lsn)).file_name end, lsn::text, pg_is_in_recovery()" +
+@@ -124,6 +128,8 @@ func (queryRunner *PgQueryRunner) BuildStartBackup() (string, error) {
+ // BuildStopBackup formats a query that stops backup according to server features and version
+ func (queryRunner *PgQueryRunner) BuildStopBackup() (string, error) {
+ 	switch {
++	case queryRunner.Version >= 150000:
++		return "SELECT labelfile, spcmapfile, lsn FROM pg_backup_stop(false)", nil
+ 	case queryRunner.Version >= 90600:
+ 		return "SELECT labelfile, spcmapfile, lsn FROM pg_stop_backup(false)", nil
+ 	case queryRunner.Version >= 90000:

--- a/SPECS/el9/wal-g.spec
+++ b/SPECS/el9/wal-g.spec
@@ -22,7 +22,7 @@ WAL-G is an archival restoration tool for PostgreSQL.
 %prep
 %setup
 # Building wal-g depends on a full git checkout, so do this after "tricking"
-# rpmbuild everything is normal by using the `autosetup` macro.
+# rpmbuild everything is normal by using the `setup` macro w/ `autopatch`.
 cd "${HOME}"
 %{__rm} -fr %{_builddir}/%{name}-%{version}
 %{__git} clone --single-branch -b v%{rpmbuild_version} %{url} %{_builddir}/%{name}-%{version}

--- a/SPECS/el9/wal-g.spec
+++ b/SPECS/el9/wal-g.spec
@@ -7,6 +7,8 @@ License:        ASL 2.0
 URL:            https://github.com/%{name}/%{name}
 Source0:        https://github.com/%{name}/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 
+Patch0:         wal-g-postgresql15.patch
+
 
 BuildRequires:  brotli-devel
 BuildRequires:  libsodium-devel
@@ -18,13 +20,14 @@ WAL-G is an archival restoration tool for PostgreSQL.
 
 
 %prep
-%autosetup
+%setup
 # Building wal-g depends on a full git checkout, so do this after "tricking"
 # rpmbuild everything is normal by using the `autosetup` macro.
 cd "${HOME}"
 %{__rm} -fr %{_builddir}/%{name}-%{version}
 %{__git} clone --single-branch -b v%{rpmbuild_version} %{url} %{_builddir}/%{name}-%{version}
 cd %{_builddir}/%{name}-%{version}
+%autopatch -p1
 
 
 %build

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -219,7 +219,7 @@ x-rpmbuild:
       version: &uriparser_version 0.9.6-1
     wal-g:
       image: rpmbuild-wal-g
-      version: &walg_version 2.0.0-1
+      version: &walg_version 2.0.0-2
   service_volumes: &service_volumes
     - ./RPMS:/rpmbuild/RPMS:rw
     - ./SOURCES/el9:/rpmbuild/SOURCES:rw


### PR DESCRIPTION
Add patch for `wal-g` to work on PostgreSQL 15 due to renaming of `pg_{start,stop}_backup` functions; refs wal-g/wal-g#1273.