### PR TITLE
Upgrade PostGIS to 3.2.2

### DIFF
--- a/SPECS/el7/postgis.spec
+++ b/SPECS/el7/postgis.spec
@@ -13,7 +13,7 @@
 %global postgis_majorversion %{postgis_major}.%{postgis_minor}
 %global postgiscurrmajorversion %(echo %{postgis_majorversion}|tr -d '.')
 
-%{!?postgis_prev_version: %global postgis_prev_version 2.5.5}
+%{!?postgis_prev_version: %global postgis_prev_version 2.5.7}
 %global postgis_prev_major %(echo %{postgis_prev_version} | awk -F. '{ print $1 }')
 %global postgis_prev_minor %(echo %{postgis_prev_version} | awk -F. '{ print $2 }')
 %global postgis_prev_micro %(echo %{postgis_prev_version} | awk -F. '{ print $3 }')

--- a/SPECS/el9/postgis.spec
+++ b/SPECS/el9/postgis.spec
@@ -13,7 +13,7 @@
 %global postgis_majorversion %{postgis_major}.%{postgis_minor}
 %global postgiscurrmajorversion %(echo %{postgis_majorversion}|tr -d '.')
 
-%{!?postgis_prev_version: %global postgis_prev_version 2.5.6}
+%{!?postgis_prev_version: %global postgis_prev_version 2.5.7}
 %global postgis_prev_major %(echo %{postgis_prev_version} | awk -F. '{ print $1 }')
 %global postgis_prev_minor %(echo %{postgis_prev_version} | awk -F. '{ print $2 }')
 %global postgis_prev_micro %(echo %{postgis_prev_version} | awk -F. '{ print $3 }')

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -139,7 +139,7 @@ x-rpmbuild:
       version: &passenger_version 6.0.14-1
     postgis:
       image: rpmbuild-postgis
-      version: &postgis_version 3.2.1-1
+      version: &postgis_version 3.2.2-1
       defines:
         gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -166,7 +166,7 @@ x-rpmbuild:
       defines:
         gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version
-        prerelease: alpha1
+        prerelease: beta2
         proj_min_version: *proj_min_version
         protobuf_min_version: *protobuf_min_version
         protobuf_c_min_version: *protobuf_c_min_version


### PR DESCRIPTION
* Upgrade to PostGIS [3.2.2](http://postgis.net/2022/07/23/postgis-3.2.2/) on EL7.
* Upgrade to PostGIS 3.3.0 beta2 on EL9.