### PR TITLE
Use `--makefile=` rather than `MAKEFILES`

### DIFF
--- a/Makefile.el7
+++ b/Makefile.el7
@@ -265,7 +265,7 @@ wal-g: $(WALG_RPM)
 
 ## Build patterns
 RPMS/x86_64/%.rpm RPMS/noarch/%.rpm: | .env
-	$(MAKE) -f Makefile.$(EL_VERSION) $(call rpmbuild_image_parent,$*)
+	$(MAKE) --makefile=Makefile.$(EL_VERSION) $(call rpmbuild_image_parent,$*)
 	$(call pull_if_ci,$(call rpmbuild_image,$*))
 	$(call build_unless_image_exists,$(call rpmbuild_image,$*))
 	COMPOSE_FILE=$(COMPOSE_FILE) $(DOCKER_COMPOSE) run --rm -T $(call rpmbuild_image,$*) \

--- a/Makefile.el9
+++ b/Makefile.el9
@@ -268,7 +268,7 @@ wal-g: $(WALG_RPM)
 
 ## Build patterns
 RPMS/x86_64/%.rpm RPMS/noarch/%.rpm: | .env
-	$(MAKE) -f Makefile.$(EL_VERSION) $(call rpmbuild_image_parent,$*)
+	$(MAKE) --makefile=Makefile.$(EL_VERSION) $(call rpmbuild_image_parent,$*)
 	$(call pull_if_ci,$(call rpmbuild_image,$*))
 	$(call build_unless_image_exists,$(call rpmbuild_image,$*))
 	COMPOSE_FILE=$(COMPOSE_FILE) $(DOCKER_COMPOSE) run --rm -T $(call rpmbuild_image,$*) \

--- a/README.md
+++ b/README.md
@@ -11,21 +11,20 @@ This repository provides a Docker-based build system for creating RPMs of the la
 * Embrace the RPM toolchain to support compilation hardening flags.
 
 ## Quickstart
+***Substitute `Makefile.el9` with `Makefile.el7` in order to target `EL7`***
 
 Just type `make $RPM_NAME`, for example start small:
 
 ```
 export DOCKER_BUILDKIT=1
-export MAKEFILES=Makefile.el9
-make FileGDBAPI
+make --makefile=Makefile.el9 FileGDBAPI
 ```
 
 Or go big and create RPMs for all applications with:
 
 ```
 export DOCKER_BUILDKIT=1
-export MAKEFILES=Makefile.el9
-make all-rpms
+make --makefile=Makefile.el9 all-rpms
 ```
 
 This will consume a lot of CPU and I/O!


### PR DESCRIPTION
Otherwise there are target duplication warnings:
```
Makefile.el9:155: warning: overriding recipe for target 'distclean'
Makefile.el9:155: warning: ignoring old recipe for target 'distclean'
Makefile.el9:163: warning: overriding recipe for target '.env'
Makefile.el9:163: warning: ignoring old recipe for target '.env'
Makefile.el9:203: warning: overriding recipe for target 'rpmbuild'
Makefile.el9:203: warning: ignoring old recipe for target 'rpmbuild'
Makefile.el9:207: warning: overriding recipe for target 'rpmbuild-fonts'
Makefile.el9:207: warning: ignoring old recipe for target 'rpmbuild-fonts'
Makefile.el9:212: warning: overriding recipe for target 'rpmbuild-generic'
Makefile.el9:212: warning: ignoring old recipe for target 'rpmbuild-generic'
Makefile.el9:217: warning: overriding recipe for target 'rpmbuild-pgdg'
Makefile.el9:217: warning: ignoring old recipe for target 'rpmbuild-pgdg'
```