### PR TITLE
Smallstep Upgrades

### DIFF
--- a/SOURCES/el7/ruby-fix-tzdata-tests.patch
+++ b/SOURCES/el7/ruby-fix-tzdata-tests.patch
@@ -1,0 +1,20 @@
+Backport of https://github.com/ruby/spec/pull/939.
+
+diff --git a/spec/ruby/core/time/shared/local.rb b/spec/ruby/core/time/shared/local.rb
+index 43f331c4c..c4aa7a7ea 100644
+--- a/spec/ruby/core/time/shared/local.rb
++++ b/spec/ruby/core/time/shared/local.rb
+@@ -8,10 +8,10 @@ describe :time_local, shared: true do
+ 
+   platform_is_not :windows do
+     describe "timezone changes" do
+-      it "correctly adjusts the timezone change to 'CEST' on 'Europe/Amsterdam'" do
++      it "correctly adjusts the timezone change to 'CET' on 'Europe/Amsterdam'" do
+         with_timezone("Europe/Amsterdam") do
+-          Time.send(@method, 1940, 5, 16).to_a.should ==
+-            [0, 40, 1, 16, 5, 1940, 4, 137, true, "CEST"]
++          Time.send(@method, 1970, 5, 16).to_a.should ==
++            [0, 0, 0, 16, 5, 1970, 6, 136, false, "CET"]
+         end
+       end
+     end

--- a/SPECS/el7/ruby.spec
+++ b/SPECS/el7/ruby.spec
@@ -171,6 +171,8 @@ Patch13: ruby-2.8.0-remove-unneeded-gem-require-for-ipaddr.patch
 Patch19: ruby-2.7.1-Timeout-the-test_bug_reporter_add-witout-raising-err.patch
 # Revert autoconf changes from 2.7.4 that cause regressions in JIT tests.
 Patch20: ruby-2.7.4-autoconf-revert.patch
+# Fix issues with using updated tzdata.
+Patch21: ruby-fix-tzdata-tests.patch
 
 Requires: %{name}-libs%{?_isa} = %{version}-%{release}
 Requires: ruby(rubygems) >= %{rubygems_version}
@@ -579,6 +581,7 @@ rm -rf ext/fiddle/libffi*
 %patch13 -p1
 %patch19 -p1
 %patch20 -p1
+%patch21 -p1
 
 # Provide an example of usage of the tapset:
 cp -a %{SOURCE3} .

--- a/SPECS/el7/step-cli.spec
+++ b/SPECS/el7/step-cli.spec
@@ -18,6 +18,8 @@ cd "${HOME}"
 %{__rm} -fr %{_builddir}/cli-%{version}
 %{__git} clone --single-branch -b v%{version} %{url} %{_builddir}/cli-%{version}
 cd %{_builddir}/cli-%{version}
+# XXX: ensure golangci-lint at latest version, remove when no longer needed.
+%{__sed} -i -e 's/v1\.48/latest/g' make/common.mk
 
 
 %build

--- a/SPECS/el9/step-cli.spec
+++ b/SPECS/el9/step-cli.spec
@@ -18,6 +18,8 @@ cd "${HOME}"
 %{__rm} -fr %{_builddir}/cli-%{version}
 %{__git} clone --single-branch -b v%{version} %{url} %{_builddir}/cli-%{version}
 cd %{_builddir}/cli-%{version}
+# XXX: ensure golangci-lint at latest version, remove when no longer needed.
+%{__sed} -i -e 's/v1\.48/latest/g' make/common.mk
 
 
 %build

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -236,10 +236,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.21.0-1
+      version: &step_ca_version 0.22.1-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.21.0-1
+      version: &step_cli_version 0.22.0-1
     tbb:
       image: rpmbuild-tbb
       version: &tbb_version 2020.3-1

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -214,10 +214,10 @@ x-rpmbuild:
         rubygems_molinillo_version: 0.5.7
         test_unit_version: 3.3.4
         xmlrpc_version: 0.3.0
-        # Use the following to run the Ruby tests on a host with
-        # ZFS on Linux:
-        # with:
-        #   - zfs_host
+      # Use the following to run the Ruby tests on a host with
+      # ZFS on Linux:
+      # with:
+      #   - zfs_host
     rubygem-pg:
       image: rpmbuild-rubygem-pg
       version: &rubygem_pg_version 1.3.5-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -226,10 +226,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.21.0-1
+      version: &step_ca_version 0.22.1-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.21.0-1
+      version: &step_cli_version 0.22.0-1
     uriparser:
       image: rpmbuild-uriparser
       version: &uriparser_version 0.9.6-1


### PR DESCRIPTION
* Upgrade `step-ca` to [0.22.1](https://github.com/smallstep/certificates/releases/tag/v0.22.1) and `step-cli` to [0.22.0](https://github.com/smallstep/cli/releases/tag/v0.22.0).
* Port in Ruby `tzdata` fix from #68; EL9 tests will continue to fail until PostGIS / PostgreSQL 15 beta4 JSON feature retraction issues are fixed.