### PR TITLE
Passenger 6.0.15

### DIFF
--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -136,7 +136,7 @@ x-rpmbuild:
         protobuf_c_min_version: *protobuf_c_min_version
     passenger:
       image: rpmbuild-passenger
-      version: &passenger_version 6.0.14-1
+      version: &passenger_version 6.0.15-1
     postgis:
       image: rpmbuild-postgis
       version: &postgis_version 3.2.3-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -167,7 +167,7 @@ x-rpmbuild:
         protobuf_c_min_version: *protobuf_c_min_version
     passenger:
       image: rpmbuild-passenger
-      version: &passenger_version 6.0.14-1
+      version: &passenger_version 6.0.15-1
     postgis:
       image: rpmbuild-postgis
       version: &postgis_version 3.3.1-1


### PR DESCRIPTION
Upgrade Phusion Passenger to [6.0.15](https://github.com/phusion/passenger/blob/stable-6.0/CHANGELOG#L6-L29).