### PR TITLE
PROJ 9.1.0 & EL9 Updates

### DIFF
--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -226,7 +226,7 @@ x-rpmbuild:
       version: &rubygem_libxml_ruby_version 3.2.2-1
     sbt:
       image: rpmbuild-generic
-      version: &sbt_version 1.6.1-1
+      version: &sbt_version 1.7.2-1
       arch: noarch
     sqlite:
       image: rpmbuild-sqlite

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -118,6 +118,7 @@ x-rpmbuild:
       image: rpmbuild-mapnik
       version: &mapnik_version 3.1.0-1
       defines:
+        gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version
         postgis_min_version: *postgis_min_version
         proj_min_version: *proj_min_version

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -32,7 +32,7 @@ x-rpmbuild:
     geos: &geos_min_version 3.11.0
     libosmium: &libosmium_min_version 2.18.0
     postgis_min_version: &postgis_min_version 3.3.0
-    proj: &proj_min_version 9.0.0
+    proj: &proj_min_version 9.1.0
     protobuf-c: &protobuf_c_min_version 1.3.0
     protobuf: &protobuf_min_version 3.0.0
     protozero: &protozero_min_version 1.7.0
@@ -178,9 +178,9 @@ x-rpmbuild:
         protobuf_c_min_version: *protobuf_c_min_version
     proj:
       image: rpmbuild-proj
-      version: &proj_version 9.0.1-1
+      version: &proj_version 9.1.0-1
       defines:
-        data_version: "1.10"
+        data_version: "1.11"
         googletest_version: 1.11.0
     protozero:
       image: rpmbuild-protozero

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -95,7 +95,7 @@ x-rpmbuild:
       version: &journald-cloudwatch-logs_version 0.2.2-1
     libgeotiff:
       image: rpmbuild-libgeotiff
-      version: &libgeotiff_version 1.7.1-10
+      version: &libgeotiff_version 1.7.1-1
       defines:
         proj_min_version: *proj_min_version
     libgta:

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -54,7 +54,7 @@ x-rpmbuild:
         _smp_ncpus_max: 4
     armadillo:
       image: rpmbuild-armadillo
-      version: &armadillo_version 11.2.0-1
+      version: &armadillo_version 11.4.1-1
     arpack:
       image: rpmbuild-arpack
       version: &arpack_version 3.8.0-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -95,7 +95,7 @@ x-rpmbuild:
       version: &journald-cloudwatch-logs_version 0.2.2-1
     libgeotiff:
       image: rpmbuild-libgeotiff
-      version: &libgeotiff_version 1.7.1-1
+      version: &libgeotiff_version 1.7.1-10
       defines:
         proj_min_version: *proj_min_version
     libgta:

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -214,7 +214,7 @@ x-rpmbuild:
       version: &rubygem_libxml_ruby_version 3.2.2-1
     sbt:
       image: rpmbuild-generic
-      version: &sbt_version 1.6.2-1
+      version: &sbt_version 1.7.2-1
       arch: noarch
     spawn-fcgi:
       image: rpmbuild-generic

--- a/scripts/pgdg-repo.sh
+++ b/scripts/pgdg-repo.sh
@@ -47,6 +47,7 @@ cat > "${PGDG_REPO}" <<EOF
 name=PostgreSQL ${POSTGRES_VERSION} \$releasever - \$basearch
 baseurl=${PGDG_BASEURL}/${POSTGRES_VERSION}/redhat/rhel-\$releasever-\$basearch
 enabled=1
+exclude=CGAL* geos* gdal* ogdi* ogr* osm* postgis* proj* SFCGAL*
 gpgcheck=1
 gpgkey=file://${PGDG_KEY}
 repo_gpgcheck=1

--- a/scripts/pgdg-repo.sh
+++ b/scripts/pgdg-repo.sh
@@ -5,7 +5,7 @@ POSTGRES_VERSION="${1}"
 PGDG_KEY="${PGDG_KEY:-/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG}"
 PGDG_REPO="${PGDG_REPO:-/etc/yum.repos.d/pgdg-${POSTGRES_VERSION}-centos.repo}"
 PGDG_BASEURL="https://download.postgresql.org/pub/repos/yum"
-if [ "${POSTGRES_VERSION}" -ge 15 ]; then
+if [ "${POSTGRES_VERSION}" -ge 16 ]; then
     PGDG_BASEURL="${PGDG_BASEURL}/testing"
 fi
 


### PR DESCRIPTION
* Upgrade to PROJ 9.1.0, and have it be minimal version for EL9 spatial packages.
* Other updates: SBT to 1.7.2, Armadillo to 11.4.1 (EL9).
* Fixes: Upgrade scripts and repository configuration for PostgreSQL 15's release & add missing `gdal_min_version` macro.