### PR TITLE
Fix `unused-rpmlintrc-filter "no-cleaning-of-buildroot"`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Lint with rpmlint
         run: |
-          rpmlint --permissive --rpmlintrc .rpmlintrc SPECS/el?/*.spec
+          rpmlint --ignore-unused-rpmlintrc --permissive --rpmlintrc .rpmlintrc SPECS/el?/*.spec
 
   shellcheck:
     name: Lint - shellcheck


### PR DESCRIPTION
Same as from https://github.com/radiant-maxar/geoint-apps/pull/16