### PR TITLE
osm2pgsql 1.7.1

### DIFF
--- a/SOURCES/el9/osm2pgsql-replication.patch
+++ b/SOURCES/el9/osm2pgsql-replication.patch
@@ -1,9 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7fbc8ce0..8e666388 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -337,6 +337,5 @@ include(GNUInstallDirs)
+ if (ENABLE_INSTALL)
+     install(TARGETS osm2pgsql DESTINATION bin)
+     install(FILES default.style empty.style DESTINATION share/osm2pgsql)
+-    install(CODE "set(OSM2PGSQL_BINDIR ${CMAKE_INSTALL_FULL_BINDIR})
+-                  configure_file(${PROJECT_SOURCE_DIR}/scripts/osm2pgsql-replication ${CMAKE_INSTALL_FULL_BINDIR}/osm2pgsql-replication)")
++    install(FILES scripts/osm2pgsql-replication DESTINATION bin)
+ endif()
 diff --git a/scripts/osm2pgsql-replication b/scripts/osm2pgsql-replication
-index 8a35e386..33f2be9d 100755
+index e721da35..961e34bb 100755
 --- a/scripts/osm2pgsql-replication
 +++ b/scripts/osm2pgsql-replication
-@@ -79,7 +79,7 @@ def connect(args):
-                            host=args.host, port=args.port)
+@@ -95,7 +95,7 @@ def table_exists(conn, table_name):
+         return cur.rowcount > 0
  
  
 -def compute_database_date(conn, prefix):
@@ -11,7 +23,7 @@ index 8a35e386..33f2be9d 100755
      """ Determine the date of the database from the newest object in the
          database.
      """
-@@ -95,7 +95,7 @@ def compute_database_date(conn, prefix):
+@@ -112,7 +112,7 @@ def compute_database_date(conn, prefix):
  
      LOG.debug("Using way id %d for timestamp lookup", osmid)
      # Get the way from the API to find the timestamp when it was created.
@@ -20,8 +32,8 @@ index 8a35e386..33f2be9d 100755
      headers = {"User-Agent" : "osm2pgsql-update",
                 "Accept" : "application/json"}
      with urlrequest.urlopen(urlrequest.Request(url, headers=headers)) as response:
-@@ -274,7 +274,7 @@ def init(conn, args):
-     this with the '--server' parameter.
+@@ -290,7 +290,7 @@ def init(conn, args):
+     this with the `--server` parameter.
      """
      if args.osm_file is None:
 -        date = compute_database_date(conn, args.prefix)
@@ -29,7 +41,7 @@ index 8a35e386..33f2be9d 100755
          if date is None:
              return 1
  
-@@ -450,6 +450,9 @@ def get_parser():
+@@ -470,6 +470,9 @@ def get_parser():
                            formatter_class=RawDescriptionHelpFormatter,
                            add_help=False)
      grp = cmd.add_argument_group('Replication source arguments')

--- a/SOURCES/el9/osm2pgsql-replication.patch
+++ b/SOURCES/el9/osm2pgsql-replication.patch
@@ -8,7 +8,7 @@ index 7fbc8ce0..8e666388 100644
      install(FILES default.style empty.style DESTINATION share/osm2pgsql)
 -    install(CODE "set(OSM2PGSQL_BINDIR ${CMAKE_INSTALL_FULL_BINDIR})
 -                  configure_file(${PROJECT_SOURCE_DIR}/scripts/osm2pgsql-replication ${CMAKE_INSTALL_FULL_BINDIR}/osm2pgsql-replication)")
-+    install(FILES scripts/osm2pgsql-replication DESTINATION bin)
++    install(PROGRAMS scripts/osm2pgsql-replication DESTINATION bin)
  endif()
 diff --git a/scripts/osm2pgsql-replication b/scripts/osm2pgsql-replication
 index e721da35..961e34bb 100755

--- a/SPECS/el9/osm2pgsql.spec
+++ b/SPECS/el9/osm2pgsql.spec
@@ -15,7 +15,7 @@ Summary:        Imports map data from OpenStreetMap to a PostgreSQL database
 License:        GPLv2+
 URL:            https://github.com/openstreetmap/osm2pgsql
 Source0:        https://github.com/openstreetmap/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
-Patch0:         osm2pgsql-replication-osm-server.patch
+Patch0:         osm2pgsql-replication.patch
 
 BuildRequires:  boost-devel
 BuildRequires:  bzip2-devel

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -159,7 +159,7 @@ x-rpmbuild:
         protozero_min_version: *protozero_min_version
     osm2pgsql:
       image: rpmbuild-osm2pgsql
-      version: &osm2pgsql_version 1.6.0-1
+      version: &osm2pgsql_version 1.7.1-1
       defines:
         libosmium_min_version: *libosmium_min_version
         proj_min_version: *proj_min_version


### PR DESCRIPTION
Upgrade to 1.7.1 on EL9 only -- I think this is end of the line for EL7, it no longer builds as newer `boost::geometry` features are now required and not present in EPEL 7's Boost packages.