### PR TITLE
Simplify PostgreSQL path definition for GDAL on EL9

### DIFF
--- a/SPECS/el9/gdal.spec
+++ b/SPECS/el9/gdal.spec
@@ -164,8 +164,7 @@ manipulating GDAL file format library
 %cmake \
     -DCMAKE_INSTALL_INCLUDEDIR:PATH=%{_includedir}/%{name} \
     -DGDAL_USE_POSTGRESQL:BOOL=ON \
-    -DPostgreSQL_INCLUDE_DIR=/usr/pgsql-%{postgres_version}/include \
-    -DPostgreSQL_LIBRARY=/usr/pgsql-%{postgres_version}/lib/libpq.so \
+    -DPostgreSQL_ROOT=/usr/pgsql-%{postgres_version} \
     -DUSE_CCACHE:BOOL=ON
 %cmake_build
 

--- a/SPECS/el9/gdal.spec
+++ b/SPECS/el9/gdal.spec
@@ -164,7 +164,7 @@ manipulating GDAL file format library
 %cmake \
     -DCMAKE_INSTALL_INCLUDEDIR:PATH=%{_includedir}/%{name} \
     -DGDAL_USE_POSTGRESQL:BOOL=ON \
-    -DPostgreSQL_ROOT=/usr/pgsql-%{postgres_version} \
+    -DPostgreSQL_ADDITIONAL_VERSIONS=%{postgres_version} \
     -DUSE_CCACHE:BOOL=ON
 %cmake_build
 


### PR DESCRIPTION
By taking advantage of `PostgreSQL_ADDITIONAL_VERSIONS`

* https://github.com/OSGeo/gdal/blob/e98b462da9f4e4195f2991c1466154ad5af36262/cmake/modules/3.20/FindPostgreSQL.cmake#L104-L105

I.E.:
https://github.com/radiant-maxar/geoint-deps/actions/runs/3491007332/jobs/5844172758#step:3:2155
```
-- Found PostgreSQL: /usr/pgsql-15/lib/libpq.so (found version "15.1")
```