### PR TITLE
Upgrade `python3-osmium` to 3.5.0.

### DIFF
--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -176,11 +176,11 @@ x-rpmbuild:
         commit: 7da019cf9eb12af8f8aa88b7d75789dfcd1e901b
     python3-osmium:
       image: rpmbuild-pyosmium
-      version: &pyosmium_version 3.4.1-1
+      version: &pyosmium_version 3.5.0-1
       defines:
         libosmium_min_version: *libosmium_min_version
         protozero_min_version: *protozero_min_version
-        pybind11_version: 2.10.0
+        pybind11_version: 2.10.1
     rack:
       image: rpmbuild-rack
       version: &rack_version 2.2.3.1-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -193,7 +193,7 @@ x-rpmbuild:
         visualcommit: 1f20cf257f35224d3c139a6015b1cf70814b0d24
     python3-osmium:
       image: rpmbuild-pyosmium
-      version: &pyosmium_version 3.4.1-1
+      version: &pyosmium_version 3.5.0-1
       defines:
         libosmium_min_version: *libosmium_min_version
         protozero_min_version: *protozero_min_version


### PR DESCRIPTION
The [3.5.0](https://github.com/osmcode/pyosmium/releases/tag/v3.5.0) release includes some minor bug fixes.