### PR TITLE
Upgrade GDAL from v3.6.0 to v3.6.1 (EL9)

### DIFF
--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -63,7 +63,7 @@ x-rpmbuild:
       version: 1.2.5-1
     gdal:
       image: rpmbuild-gdal
-      version: &gdal_version 3.6.0-1
+      version: &gdal_version 3.6.1-1
       defines:
         geos_min_version: *geos_min_version
         proj_min_version: *proj_min_version


### PR DESCRIPTION
v3.6.0 has been retracted

https://github.com/OSGeo/gdal/releases