### PR TITLE
Upgrade Phusion Passenger from v6.0.15 to v6.0.16 (EL9)

### DIFF
--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -160,7 +160,7 @@ x-rpmbuild:
         protobuf_c_min_version: *protobuf_c_min_version
     passenger:
       image: rpmbuild-passenger
-      version: &passenger_version 6.0.15-1
+      version: &passenger_version 6.0.16-1
     postgis:
       image: rpmbuild-postgis
       version: &postgis_version 3.3.2-1


### PR DESCRIPTION
https://github.com/phusion/passenger/releases/tag/release-6.0.16