### PR TITLE
Fix `GDAL`, `gpsbabel` & `libosmium` build linking errors (EL9)

### DIFF
--- a/SPECS/el9/gdal.spec
+++ b/SPECS/el9/gdal.spec
@@ -161,6 +161,8 @@ manipulating GDAL file format library
 
 
 %build
+# LTO appears to cause some issues.
+# https://bugzilla.redhat.com/show_bug.cgi?id=2065758
 %cmake \
     -DCMAKE_INSTALL_INCLUDEDIR:PATH=%{_includedir}/%{name} \
     -DGDAL_USE_POSTGRESQL:BOOL=ON \

--- a/SPECS/el9/gdal.spec
+++ b/SPECS/el9/gdal.spec
@@ -163,6 +163,7 @@ manipulating GDAL file format library
 %build
 # LTO appears to cause some issues.
 # https://bugzilla.redhat.com/show_bug.cgi?id=2065758
+%define _lto_cflags %{nil}
 %cmake \
     -DCMAKE_INSTALL_INCLUDEDIR:PATH=%{_includedir}/%{name} \
     -DGDAL_USE_POSTGRESQL:BOOL=ON \

--- a/SPECS/el9/gpsbabel.spec
+++ b/SPECS/el9/gpsbabel.spec
@@ -42,9 +42,11 @@ Qt GUI interface for GPSBabel
 
 
 %build
+# LTO appears to cause some issues.
+# https://bugzilla.redhat.com/show_bug.cgi?id=2065758
+%define _lto_cflags %{nil}
 %cmake \
   -DGPSBABEL_WITH_ZLIB=pkgconfig \
-  -DGPS_BABEL_WITH_SHAPE_LIB=pkgconfig \
   -DGPSBABEL_WITH_SHAPELIB=pkgconfig \
   ..
 %cmake_build
@@ -76,6 +78,10 @@ desktop-file-install \
 %{__install} -m 0644 -p %{SOURCE2} %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/
 
 %find_lang %{name} --with-qt --all-name
+
+
+%check
+%ctest
 
 
 %files

--- a/SPECS/el9/libosmium.spec
+++ b/SPECS/el9/libosmium.spec
@@ -54,6 +54,9 @@ developing applications that use %{name}.
 
 
 %build
+# LTO appears to cause some issues.
+# https://bugzilla.redhat.com/show_bug.cgi?id=2065758
+%define _lto_cflags %{nil}
 %cmake -DBUILD_HEADERS=OFF -DINSTALL_GDALCPP=ON
 %cmake_build
 

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -72,7 +72,7 @@ x-rpmbuild:
       version: &geos_version 3.11.1-1
     gpsbabel:
       image: rpmbuild-gpsbabel
-      version: &gpsbabel_version 1.8.0-1
+      version: &gpsbabel_version 1.8.0-2
     g2clib:
       image: rpmbuild-g2clib
       name: g2clib-devel
@@ -99,7 +99,7 @@ x-rpmbuild:
       version: &libkml_version 1.3.0-1
     libosmium:
       image: rpmbuild-libosmium
-      version: &libosmium_version 2.18.0-1
+      version: &libosmium_version 2.18.0-2
       arch: noarch
       name: libosmium-devel
       defines:

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -99,7 +99,7 @@ x-rpmbuild:
       version: &libkml_version 1.3.0-1
     libosmium:
       image: rpmbuild-libosmium
-      version: &libosmium_version 2.18.0-2
+      version: &libosmium_version 2.18.0-1
       arch: noarch
       name: libosmium-devel
       defines:


### PR DESCRIPTION
I.E.:
* [GDAL](https://github.com/radiant-maxar/geoint-deps/actions/runs/3886557657/jobs/6632575758#step:3:14275)
* [gpsbabel](https://github.com/radiant-maxar/geoint-deps/actions/runs/3884999029/jobs/6628981925#step:3:645)
* [libosmium](https://github.com/radiant-maxar/geoint-deps/actions/runs/3884999029/jobs/6628982608#step:3:2062)

Sometime after the [latest successful _**stable**_ build](https://github.com/radiant-maxar/geoint-deps/actions/runs/3715748180) on `December 16th, 2022`, an updated package seems to have broken some of these `geoint-deps` builds. This seems to be related to [this issue](https://bugzilla.redhat.com/show_bug.cgi?id=2065758) which was resolved by disabling LTO. In Rawhide, the underlying issue appears to have been fixed almost a year ago.

This issue is currently preventing builds from completing.

**Also:**
* Enabled tests for `gpsbabel`