### PR TITLE
PROJ Data Subpackage

### DIFF
--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -154,10 +154,9 @@ x-rpmbuild:
         protobuf_c_min_version: *protobuf_c_min_version
     proj:
       image: rpmbuild-proj
-      version: &proj_version 9.1.1-1
+      version: &proj_version 9.1.1-2
       defines:
         data_version: "1.12"
-        googletest_version: 1.11.0
     protozero:
       image: rpmbuild-protozero
       version: &protozero_version 1.7.1-1

--- a/docker/el9/Dockerfile.rpmbuild-gdal
+++ b/docker/el9/Dockerfile.rpmbuild-gdal
@@ -35,6 +35,7 @@ COPY RPMS/x86_64/CGAL-devel-${cgal_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libgeotiff-devel-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
+     RPMS/noarch/proj-data-${proj_version}${RPMBUILD_DIST}.noarch.rpm \
      RPMS/noarch/proj-data-at-${proj_version}${RPMBUILD_DIST}.noarch.rpm \
      RPMS/noarch/proj-data-au-${proj_version}${RPMBUILD_DIST}.noarch.rpm \
      RPMS/noarch/proj-data-be-${proj_version}${RPMBUILD_DIST}.noarch.rpm \
@@ -88,6 +89,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     "/tmp/libgeotiff-devel-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm" \
     "/tmp/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm" \
     "/tmp/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm" \
+    "/tmp/proj-data-${proj_version}${RPMBUILD_DIST}.noarch.rpm" \
     "/tmp/proj-data-at-${proj_version}${RPMBUILD_DIST}.noarch.rpm" \
     "/tmp/proj-data-au-${proj_version}${RPMBUILD_DIST}.noarch.rpm" \
     "/tmp/proj-data-be-${proj_version}${RPMBUILD_DIST}.noarch.rpm" \

--- a/docker/el9/Dockerfile.rpmbuild-libgeotiff
+++ b/docker/el9/Dockerfile.rpmbuild-libgeotiff
@@ -8,6 +8,7 @@ ARG proj_version
 
 COPY RPMS/x86_64/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm \
+     RPMS/noarch/proj-data-${proj_version}${RPMBUILD_DIST}.noarch.rpm \
      RPMS/noarch/proj-data-at-${proj_version}${RPMBUILD_DIST}.noarch.rpm \
      RPMS/noarch/proj-data-au-${proj_version}${RPMBUILD_DIST}.noarch.rpm \
      RPMS/noarch/proj-data-be-${proj_version}${RPMBUILD_DIST}.noarch.rpm \
@@ -47,6 +48,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y \
     "/tmp/proj-${proj_version}${RPMBUILD_DIST}.x86_64.rpm" \
     "/tmp/proj-devel-${proj_version}${RPMBUILD_DIST}.x86_64.rpm" \
+    "/tmp/proj-data-${proj_version}${RPMBUILD_DIST}.noarch.rpm" \
     "/tmp/proj-data-at-${proj_version}${RPMBUILD_DIST}.noarch.rpm" \
     "/tmp/proj-data-au-${proj_version}${RPMBUILD_DIST}.noarch.rpm" \
     "/tmp/proj-data-be-${proj_version}${RPMBUILD_DIST}.noarch.rpm" \


### PR DESCRIPTION
I thought the `proj-data` package wasn't necessary and I was wrong, as now EPEL's `proj-data-*` packages are getting installed instead of ours.   For example, any EL9 installation of our `gdal` or `postgis` packages has the following:

```
$ rpm -qa | grep proj
proj-data-za-8.2.0-1.el9.noarch
proj-data-us-8.2.0-1.el9.noarch
proj-data-uk-8.2.0-1.el9.noarch
proj-data-sk-8.2.0-1.el9.noarch
proj-data-se-8.2.0-1.el9.noarch
proj-data-pt-8.2.0-1.el9.noarch
proj-data-nz-8.2.0-1.el9.noarch
proj-data-no-8.2.0-1.el9.noarch
proj-data-nl-8.2.0-1.el9.noarch
proj-data-nc-8.2.0-1.el9.noarch
proj-data-mx-8.2.0-1.el9.noarch
proj-data-jp-8.2.0-1.el9.noarch
proj-data-is-8.2.0-1.el9.noarch
proj-data-fr-8.2.0-1.el9.noarch
proj-data-fo-8.2.0-1.el9.noarch
proj-data-fi-8.2.0-1.el9.noarch
proj-data-eur-8.2.0-1.el9.noarch
proj-data-es-8.2.0-1.el9.noarch
proj-data-dk-8.2.0-1.el9.noarch
proj-data-de-8.2.0-1.el9.noarch
proj-data-ch-8.2.0-1.el9.noarch
proj-data-ca-8.2.0-1.el9.noarch
proj-data-br-8.2.0-1.el9.noarch
proj-data-be-8.2.0-1.el9.noarch
proj-data-au-8.2.0-1.el9.noarch
proj-data-at-8.2.0-1.el9.noarch
proj-9.1.1-1.el9.x86_64
```

 Thus I synced relevant [changes from `proj.spec` upstream](https://src.fedoraproject.org/rpms/proj/blob/rawhide/f/proj.spec):
  * `proj-data` package is now back, hence new `9.1.1-2` release.
  * EPEL has `gtest` package now, no need to download `googletest` and install in source directory
  * Data subpackages: fix quoting and add `Supplements:` so they'll take precedence over EPEL's.