### PR TITLE
Upgrade OpenStreetMap Carto from v5.6.2 to v5.7.0 (EL9)

### DIFF
--- a/SPECS/el9/openstreetmap-carto.spec
+++ b/SPECS/el9/openstreetmap-carto.spec
@@ -32,8 +32,6 @@ Source8:        https://github.com/notofonts/noto-fonts/raw/%{fonts_google_noto_
 Source9:        https://github.com/notofonts/noto-fonts/raw/%{fonts_google_noto_git_ref}/hinted/ttf/NotoSans/NotoSans-Bold.ttf
 Source10:       https://github.com/notofonts/noto-fonts/raw/%{fonts_google_noto_git_ref}/hinted/ttf/NotoSans/NotoSans-Italic.ttf
 Source11:       https://github.com/notofonts/noto-fonts/raw/%{fonts_google_noto_git_ref}/hinted/ttf/NotoSans/NotoSans-Regular.ttf
-Source12:       https://github.com/notofonts/noto-fonts/raw/%{fonts_google_noto_git_ref}/hinted/ttf/NotoSansAdlam/NotoSansAdlam-Bold.ttf
-Source13:       https://github.com/notofonts/noto-fonts/raw/%{fonts_google_noto_git_ref}/hinted/ttf/NotoSansAdlam/NotoSansAdlam-Regular.ttf
 Source14:       https://github.com/notofonts/noto-fonts/raw/%{fonts_google_noto_git_ref}/hinted/ttf/NotoSansAdlamUnjoined/NotoSansAdlamUnjoined-Bold.ttf
 Source15:       https://github.com/notofonts/noto-fonts/raw/%{fonts_google_noto_git_ref}/hinted/ttf/NotoSansAdlamUnjoined/NotoSansAdlamUnjoined-Regular.ttf
 Source16:       https://github.com/notofonts/noto-fonts/raw/%{fonts_google_noto_git_ref}/hinted/ttf/NotoSansArabicUI/NotoSansArabicUI-Bold.ttf

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -106,7 +106,7 @@ x-rpmbuild:
         proj_min_version: *proj_min_version
     openstreetmap-carto:
       image: rpmbuild-openstreetmap-carto
-      version: &openstreetmap_carto_version 5.6.2-1
+      version: &openstreetmap_carto_version 5.7.0-1
       arch: noarch
       defines:
         data_natural_earth_version: 5.1.0


### PR DESCRIPTION
https://github.com/gravitystorm/openstreetmap-carto/compare/v5.6.2...v5.7.0