### PR TITLE
Upgrade Go Packages

### DIFF
--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -80,7 +80,7 @@ x-rpmbuild:
         proj_min_version: *proj_min_version
     journald-cloudwatch-logs:
       image: rpmbuild-journald-cloudwatch-logs
-      version: &journald-cloudwatch-logs_version 0.2.2-1
+      version: &journald-cloudwatch-logs_version 0.2.3-1
     libkml:
       image: rpmbuild-libkml
       version: &libkml_version 1.3.0-1
@@ -232,10 +232,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.23.0-1
+      version: &step_ca_version 0.23.1-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.23.0-1
+      version: &step_cli_version 0.23.1-1
     tbb:
       image: rpmbuild-tbb
       version: &tbb_version 2020.3-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -73,7 +73,7 @@ x-rpmbuild:
       version: &iniparser_version 4.1-1
     journald-cloudwatch-logs:
       image: rpmbuild-journald-cloudwatch-logs
-      version: &journald-cloudwatch-logs_version 0.2.2-1
+      version: &journald-cloudwatch-logs_version 0.2.3-1
     libgeotiff:
       image: rpmbuild-libgeotiff
       version: &libgeotiff_version 1.7.1-10
@@ -193,10 +193,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.23.0-1
+      version: &step_ca_version 0.23.1-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.23.0-1
+      version: &step_cli_version 0.23.1-1
     wal-g:
       image: rpmbuild-wal-g
       version: &walg_version 2.0.1-1

--- a/docker/el7/Dockerfile.rpmbuild-go
+++ b/docker/el7/Dockerfile.rpmbuild-go
@@ -3,8 +3,8 @@ ARG rpmbuild_image=rpmbuild-generic
 ARG rpmbuild_image_prefix
 # hadolint ignore=DL3007
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
-ARG go_version=1.19.3
-ARG go_checksum=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
+ARG go_version=1.19.5
+ARG go_checksum=36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95
 ARG packages
 
 ENV GOPATH=${RPMBUILD_HOME}/go

--- a/docker/el9/Dockerfile.rpmbuild-go
+++ b/docker/el9/Dockerfile.rpmbuild-go
@@ -3,8 +3,8 @@ ARG rpmbuild_image=rpmbuild-generic
 ARG rpmbuild_image_prefix
 # hadolint ignore=DL3007
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
-ARG go_version=1.19.3
-ARG go_checksum=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
+ARG go_version=1.19.5
+ARG go_checksum=36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95
 ARG packages
 
 ENV GOPATH=${RPMBUILD_HOME}/go


### PR DESCRIPTION
* Upgrade Go compiler to [1.19.5](https://go.dev/doc/devel/release#go1.19).
* Upgrade `journald-cloudwatch-logs` to [0.2.3](https://github.com/radiant-maxar/journald-cloudwatch-logs/releases/tag/v0.2.3).
* Upgrade `step-cli` to [0.23.1](https://github.com/smallstep/cli/releases/tag/v0.23.1) and `step-ca` to [0.23.1](https://github.com/smallstep/certificates/releases/tag/v0.23.1).