### PR TITLE
Upgrade passenger from v6.0.16 to v6.0.17 (EL9)

### DIFF
--- a/SPECS/el9/passenger.spec
+++ b/SPECS/el9/passenger.spec
@@ -78,11 +78,6 @@ BuildRequires: zlib-devel
 %if 0%{?rhel} >= 9 || 0%{?fedora} >= 34
 BuildRequires: g++
 %endif
-%if 0%{?rhel} >= 6 || 0%{?fedora} >= 12
-BuildRequires: libcurl-devel
-%else
-BuildRequires: curl-devel
-%endif
 %if 0%{?rhel} >= 8 || 0%{?fedora} >= 28
 BuildRequires: /usr/bin/pathfix.py
 BuildRequires: python3-devel

--- a/SPECS/el9/passenger.spec
+++ b/SPECS/el9/passenger.spec
@@ -75,9 +75,6 @@ BuildRequires: rubygem-rake
 BuildRequires: rubygem-rack
 BuildRequires: zlib-devel
 
-%if 0%{?rhel} >= 9 || 0%{?fedora} >= 34
-BuildRequires: g++
-%endif
 %if 0%{?rhel} >= 8 || 0%{?fedora} >= 28
 BuildRequires: /usr/bin/pathfix.py
 BuildRequires: python3-devel

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -142,7 +142,7 @@ x-rpmbuild:
         protobuf_c_min_version: *protobuf_c_min_version
     passenger:
       image: rpmbuild-passenger
-      version: &passenger_version 6.0.16-1
+      version: &passenger_version 6.0.17-1
     postgis:
       image: rpmbuild-postgis
       version: &postgis_version 3.3.2-1


### PR DESCRIPTION
https://github.com/phusion/passenger/releases

Also synchronized several sections of the `.spec` file with the current upstream version from [here](https://oss-binaries.phusionpassenger.com/yum/passenger/el/9/x86_64/passenger-6.0.17-1.el9.src.rpm) in order to fix the `SIGSEGV(11)` errors.

I.E.:
```
[ pid=271, timestamp=1674261045 ] Process aborted! signo=SIGSEGV(11), reason=SEGV_MAPERR, si_addr=0x40c, randomSeed=1674261045
```

The relevant section most likely being [these lines](https://github.com/radiant-maxar/geoint-deps/compare/PassengerFix?expand=1#diff-d71c5782730ade8150120ce07cb6b43405944266f8d948be35e88dd9652ed875R133-R135).