### PR TITLE
Add check steps to step-ca & step-cli builds

### DIFF
--- a/SPECS/el7/step-ca.spec
+++ b/SPECS/el7/step-ca.spec
@@ -101,6 +101,11 @@ getent passwd %{step_ca_user} >/dev/null || \
         %{step_ca_user}
 
 
+%check
+export CI=true
+%{__make} test
+
+
 %files
 %doc CHANGELOG.md README.md
 %license LICENSE

--- a/SPECS/el7/step-cli.spec
+++ b/SPECS/el7/step-cli.spec
@@ -31,6 +31,11 @@ cd %{_builddir}/cli-%{version}
 %{__install} -p bin/step %{buildroot}%{_bindir}
 
 
+%check
+export CI=true
+%{__make} test
+
+
 %files
 %doc CHANGELOG.md README.md
 %license LICENSE

--- a/SPECS/el9/step-ca.spec
+++ b/SPECS/el9/step-ca.spec
@@ -111,6 +111,11 @@ getent passwd %{step_ca_user} >/dev/null || \
         %{step_ca_user}
 
 
+%check
+export CI=true
+%{__make} test
+
+
 %files
 %doc CHANGELOG.md README.md
 %license LICENSE

--- a/SPECS/el9/step-cli.spec
+++ b/SPECS/el9/step-cli.spec
@@ -31,6 +31,11 @@ cd %{_builddir}/cli-%{version}
 %{__install} -p bin/step %{buildroot}%{_bindir}
 
 
+%check
+export CI=true
+%{__make} test
+
+
 %files
 %doc CHANGELOG.md README.md
 %license LICENSE


### PR DESCRIPTION
`CI=true` is needed since some tests are being skipped based on it.

I.E.
https://github.com/smallstep/certificates/blob/d46c5b2f4097c3c5423422ced68df680e7f52bd8/ca/bootstrap_test.go#L382-L384