### PR TITLE
Syncing some recent EL9 version updates (EL7)

### DIFF
--- a/SOURCES/el7/libosmium-CentOS7GCC.patch
+++ b/SOURCES/el7/libosmium-CentOS7GCC.patch
@@ -1,11 +1,5 @@
-commit 1b011a96081023e98d58216261c95c64c44f4624
-Author: David Hummel <6109326+hummeltech@users.noreply.github.com>
-Date:   Thu Jan 27 11:58:08 2022 -0700
-
-    Fixing build errors
-
 diff --git a/include/osmium/dynamic_handler.hpp b/include/osmium/dynamic_handler.hpp
-index 6c2a5378..df380fe4 100644
+index 73f2ac54..17e270c5 100644
 --- a/include/osmium/dynamic_handler.hpp
 +++ b/include/osmium/dynamic_handler.hpp
 @@ -130,7 +130,11 @@ auto _name_##_dispatch(THandler& handler, const osmium::_type_& object, long) ->
@@ -21,7 +15,7 @@ index 6c2a5378..df380fe4 100644
                  ~HandlerWrapper() noexcept override = default;
  
 diff --git a/include/osmium/index/detail/vector_map.hpp b/include/osmium/index/detail/vector_map.hpp
-index fd643144..6b830cfc 100644
+index d9ee56db..1f859f38 100644
 --- a/include/osmium/index/detail/vector_map.hpp
 +++ b/include/osmium/index/detail/vector_map.hpp
 @@ -69,7 +69,11 @@ namespace osmium {
@@ -49,7 +43,7 @@ index fd643144..6b830cfc 100644
                  ~VectorBasedSparseMap() noexcept override = default;
  
 diff --git a/include/osmium/index/detail/vector_multimap.hpp b/include/osmium/index/detail/vector_multimap.hpp
-index 3b479620..08f8bec3 100644
+index ab272618..7bf3eba3 100644
 --- a/include/osmium/index/detail/vector_multimap.hpp
 +++ b/include/osmium/index/detail/vector_multimap.hpp
 @@ -79,7 +79,11 @@ namespace osmium {
@@ -64,8 +58,39 @@ index 3b479620..08f8bec3 100644
  
                  ~VectorBasedSparseMultimap() noexcept override = default;
  
+diff --git a/include/osmium/index/id_set.hpp b/include/osmium/index/id_set.hpp
+index c2f44c59..152ebf2e 100644
+--- a/include/osmium/index/id_set.hpp
++++ b/include/osmium/index/id_set.hpp
+@@ -272,10 +272,11 @@ namespace osmium {
+             }
+ 
+             IdSetDense(IdSetDense&&) noexcept = default;
+-
+-            // This should really be noexcept, but GCC 4.8 doesn't like it.
+-            // NOLINTNEXTLINE(hicpp-noexcept-move, performance-noexcept-move-constructor)
++#ifdef OSMIUM_MOVE_EXCEPT
+             IdSetDense& operator=(IdSetDense&&) = default;
++#else
++            IdSetDense& operator=(IdSetDense&&) noexcept = default;
++#endif
+ 
+             ~IdSetDense() noexcept override = default;
+ 
+@@ -389,7 +390,11 @@ namespace osmium {
+             IdSetSmall& operator=(const IdSetSmall&) = default;
+ 
+             IdSetSmall(IdSetSmall&&) noexcept = default;
++#ifdef OSMIUM_MOVE_EXCEPT
++            IdSetSmall& operator=(IdSetSmall&&) = default;
++#else
+             IdSetSmall& operator=(IdSetSmall&&) noexcept = default;
++#endif
+ 
+             ~IdSetSmall() noexcept override = default;
+ 
 diff --git a/include/osmium/util/compatibility.hpp b/include/osmium/util/compatibility.hpp
-index bce554fb..617bbd15 100644
+index c37ef586..67b844d1 100644
 --- a/include/osmium/util/compatibility.hpp
 +++ b/include/osmium/util/compatibility.hpp
 @@ -33,6 +33,16 @@ DEALINGS IN THE SOFTWARE.
@@ -82,6 +107,6 @@ index bce554fb..617bbd15 100644
 +# endif
 +#endif
 +
- // Workarounds for MSVC which doesn't support [[noreturn]]
- // This is not needed any more, but kept here for the time being, because
- // older versions of osmium-tool need it.
+ // [[deprecated]] is only available in C++14, use this for the time being
+ #ifdef __GNUC__
+ # define OSMIUM_DEPRECATED __attribute__((deprecated))

--- a/SPECS/el7/rubygem-libxml-ruby.spec
+++ b/SPECS/el7/rubygem-libxml-ruby.spec
@@ -54,11 +54,9 @@ is your need, this is a good library to consider.
 %doc %{gem_instdir}/%{gem_name}.gemspec
 %doc %{gem_instdir}/script
 %doc %{gem_instdir}/test
-%doc %{gem_instdir}/MANIFEST
 %doc %{gem_instdir}/Rakefile
 %license %{gem_instdir}/LICENSE
 %dir %{gem_instdir}
-%{gem_instdir}/setup.rb
 %{gem_extdir_mri}
 %{gem_libdir}
 %exclude %{gem_cache}

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -176,11 +176,11 @@ x-rpmbuild:
         commit: 7da019cf9eb12af8f8aa88b7d75789dfcd1e901b
     python3-osmium:
       image: rpmbuild-pyosmium
-      version: &pyosmium_version 3.6.0-1
+      version: &pyosmium_version 3.5.0-1
       defines:
         libosmium_min_version: *libosmium_min_version
         protozero_min_version: *protozero_min_version
-        pybind11_version: 2.10.3
+        pybind11_version: 2.10.1
     rack:
       image: rpmbuild-rack
       version: &rack_version 2.2.4-1

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -30,7 +30,7 @@ x-rpmbuild:
   minimum_versions:
     gdal: &gdal_min_version 3.2.0
     geos: &geos_min_version 3.9.0
-    libosmium: &libosmium_min_version 2.16.0
+    libosmium: &libosmium_min_version 2.17.0
     postgis_min_version: &postgis_min_version 3.1.0
     proj: &proj_min_version 7.2.0
     protobuf-c: &protobuf_c_min_version 1.3.0
@@ -86,7 +86,7 @@ x-rpmbuild:
       version: &libkml_version 1.3.0-1
     libosmium:
       image: rpmbuild-libosmium
-      version: &libosmium_version 2.17.3-1
+      version: &libosmium_version 2.19.0-1
       arch: noarch
       name: libosmium-devel
       defines:
@@ -130,13 +130,13 @@ x-rpmbuild:
       image: rpmbuild-osm2pgsql
       version: &osm2pgsql_version 1.6.0-1
       defines:
-        libosmium_min_version: 2.17.3
+        libosmium_min_version: *libosmium_min_version
         proj_min_version: *proj_min_version
         postgis_min_version: *postgis_min_version
         protobuf_c_min_version: *protobuf_c_min_version
     passenger:
       image: rpmbuild-passenger
-      version: &passenger_version 6.0.15-1
+      version: &passenger_version 6.0.17-1
     postgis:
       image: rpmbuild-postgis
       version: &postgis_version 3.2.4-1
@@ -158,12 +158,12 @@ x-rpmbuild:
       version: &protobuf_version 3.17.3-1
     protobuf-c:
       image: rpmbuild-protobuf-c
-      version: &protobuf-c_version 1.4.0-1
+      version: &protobuf-c_version 1.4.1-1
       defines:
         protobuf_c_min_version: *protobuf_c_min_version
     protozero:
       image: rpmbuild-protozero
-      version: &protozero_version 1.7.0-1
+      version: &protozero_version 1.7.1-1
       arch: noarch
       name: protozero-devel
       defines:
@@ -176,11 +176,11 @@ x-rpmbuild:
         commit: 7da019cf9eb12af8f8aa88b7d75789dfcd1e901b
     python3-osmium:
       image: rpmbuild-pyosmium
-      version: &pyosmium_version 3.5.0-1
+      version: &pyosmium_version 3.6.0-1
       defines:
         libosmium_min_version: *libosmium_min_version
         protozero_min_version: *protozero_min_version
-        pybind11_version: 2.10.1
+        pybind11_version: 2.10.3
     rack:
       image: rpmbuild-rack
       version: &rack_version 2.2.4-1
@@ -219,10 +219,10 @@ x-rpmbuild:
       version: &rubygem_pg_version 1.3.5-1
     rubygem-libxml-ruby:
       image: rpmbuild-rubygem-libxml-ruby
-      version: &rubygem_libxml_ruby_version 3.2.4-1
+      version: &rubygem_libxml_ruby_version 4.0.0-1
     sbt:
       image: rpmbuild-generic
-      version: &sbt_version 1.7.2-1
+      version: &sbt_version 1.8.2-1
       arch: noarch
     sqlite:
       image: rpmbuild-sqlite


### PR DESCRIPTION
* libosmium: `v2.17.3` to `v2.19.0`
* passenger: `v6.0.15` to `v6.0.17`
* protobuf-c: `v1.4.0` to `v1.4.1`
* protozero: `v1.7.0` to `v1.7.1`
* rubygem-libxml-ruby: `v3.2.4` to `v4.0.0`
* sbt: `v1.7.2` to `v1.8.2`

`libosmium` dependents can follow