### PR TITLE
Upgrade step-ca/step-cli from v0.23.1 to v0.23.2

### DIFF
--- a/SPECS/el7/step-ca.spec
+++ b/SPECS/el7/step-ca.spec
@@ -38,11 +38,7 @@ cd %{_builddir}/certificates-%{version}
  %{buildroot}%{_unitdir}
 %{__install} -d -m 0700 %{buildroot}%{step_ca_home}
 %{__install} -p \
- bin/step-awskms-init \
  bin/step-ca \
- bin/step-cloudkms-init \
- bin/step-pkcs11-init \
- bin/step-yubikey-init \
  %{buildroot}%{_bindir}
 
 # Environment file.
@@ -109,11 +105,7 @@ export CI=true
 %files
 %doc CHANGELOG.md README.md
 %license LICENSE
-%{_bindir}/step-awskms-init
 %{_bindir}/step-ca
-%{_bindir}/step-cloudkms-init
-%{_bindir}/step-pkcs11-init
-%{_bindir}/step-yubikey-init
 %{_unitdir}/step-ca.service
 %config(noreplace) %{_sysconfdir}/sysconfig/step-ca
 %defattr(-, %{step_ca_user}, %{step_ca_group}, -)

--- a/SPECS/el7/step-ca.spec
+++ b/SPECS/el7/step-ca.spec
@@ -34,6 +34,7 @@ cd %{_builddir}/certificates-%{version}
 %install
 %{__install} -d -m 0755 \
  %{buildroot}%{_bindir} \
+ %{buildroot}%{_rundir}/step-ca \
  %{buildroot}%{_sysconfdir}/sysconfig \
  %{buildroot}%{_unitdir}
 %{__install} -d -m 0700 %{buildroot}%{step_ca_home}
@@ -56,7 +57,7 @@ After=basic.target network.target
 User=%{step_ca_user}
 Group=%{step_ca_group}
 EnvironmentFile=%{_sysconfdir}/sysconfig/step-ca
-ExecStart=%{_bindir}/step-ca "\${STEPPATH}/config/ca.json"
+ExecStart=%{_bindir}/step-ca --pidfile "%{_rundir}/step-ca/step-ca.pid" "\${STEPPATH}/config/ca.json"
 KillMode=process
 Restart=on-failure
 RestartSec=30s
@@ -109,6 +110,7 @@ export CI=true
 %{_unitdir}/step-ca.service
 %config(noreplace) %{_sysconfdir}/sysconfig/step-ca
 %defattr(-, %{step_ca_user}, %{step_ca_group}, -)
+%dir %{_rundir}/step-ca
 %dir %{step_ca_home}
 
 

--- a/SPECS/el7/step-ca.spec
+++ b/SPECS/el7/step-ca.spec
@@ -34,13 +34,17 @@ cd %{_builddir}/certificates-%{version}
 %install
 %{__install} -d -m 0755 \
  %{buildroot}%{_bindir} \
- %{buildroot}%{_rundir}/step-ca \
  %{buildroot}%{_sysconfdir}/sysconfig \
- %{buildroot}%{_unitdir}
-%{__install} -d -m 0700 %{buildroot}%{step_ca_home}
+ %{buildroot}%{_unitdir} \
+ %{buildroot}%{_usr}/lib/tmpfiles.d
+%{__install} -d -m 0750 \
+ %{buildroot}%{step_ca_home} \
+ %{buildroot}%{_rundir}/step-ca
 %{__install} -p \
  bin/step-ca \
  %{buildroot}%{_bindir}
+echo "d %{_rundir}/%{name} 0750 %{step_ca_user} %{step_ca_group} -" > \
+     %{buildroot}%{_usr}/lib/tmpfiles.d/step-ca.conf
 
 # Environment file.
 cat <<EOF > %{buildroot}%{_sysconfdir}/sysconfig/step-ca
@@ -57,7 +61,7 @@ After=basic.target network.target
 User=%{step_ca_user}
 Group=%{step_ca_group}
 EnvironmentFile=%{_sysconfdir}/sysconfig/step-ca
-ExecStart=%{_bindir}/step-ca --pidfile "%{_rundir}/step-ca/step-ca.pid" "\${STEPPATH}/config/ca.json"
+ExecStart=%{_bindir}/step-ca "\${STEPPATH}/config/ca.json"
 KillMode=process
 Restart=on-failure
 RestartSec=30s
@@ -108,6 +112,7 @@ export CI=true
 %license LICENSE
 %{_bindir}/step-ca
 %{_unitdir}/step-ca.service
+%{_usr}/lib/tmpfiles.d/step-ca.conf
 %config(noreplace) %{_sysconfdir}/sysconfig/step-ca
 %defattr(-, %{step_ca_user}, %{step_ca_group}, -)
 %dir %{_rundir}/step-ca

--- a/SPECS/el9/step-ca.spec
+++ b/SPECS/el9/step-ca.spec
@@ -38,11 +38,7 @@ cd %{_builddir}/certificates-%{version}
  %{buildroot}%{_unitdir}
 %{__install} -d -m 0700 %{buildroot}%{step_ca_home}
 %{__install} -p \
- bin/step-awskms-init \
  bin/step-ca \
- bin/step-cloudkms-init \
- bin/step-pkcs11-init \
- bin/step-yubikey-init \
  %{buildroot}%{_bindir}
 
 # Environment file.
@@ -119,11 +115,7 @@ export CI=true
 %files
 %doc CHANGELOG.md README.md
 %license LICENSE
-%{_bindir}/step-awskms-init
 %{_bindir}/step-ca
-%{_bindir}/step-cloudkms-init
-%{_bindir}/step-pkcs11-init
-%{_bindir}/step-yubikey-init
 %{_unitdir}/step-ca.service
 %config(noreplace) %{_sysconfdir}/sysconfig/step-ca
 %defattr(-, %{step_ca_user}, %{step_ca_group}, -)

--- a/SPECS/el9/step-ca.spec
+++ b/SPECS/el9/step-ca.spec
@@ -34,13 +34,17 @@ cd %{_builddir}/certificates-%{version}
 %install
 %{__install} -d -m 0755 \
  %{buildroot}%{_bindir} \
- %{buildroot}%{_rundir}/step-ca \
  %{buildroot}%{_sysconfdir}/sysconfig \
- %{buildroot}%{_unitdir}
-%{__install} -d -m 0700 %{buildroot}%{step_ca_home}
+ %{buildroot}%{_unitdir} \
+ %{buildroot}%{_usr}/lib/tmpfiles.d
+%{__install} -d -m 0750 \
+ %{buildroot}%{step_ca_home} \
+ %{buildroot}%{_rundir}/step-ca
 %{__install} -p \
  bin/step-ca \
  %{buildroot}%{_bindir}
+echo "d %{_rundir}/%{name} 0750 %{step_ca_user} %{step_ca_group} -" > \
+     %{buildroot}%{_usr}/lib/tmpfiles.d/step-ca.conf
 
 # Environment file.
 cat <<EOF > %{buildroot}%{_sysconfdir}/sysconfig/step-ca
@@ -57,7 +61,7 @@ After=basic.target network.target
 User=%{step_ca_user}
 Group=%{step_ca_group}
 EnvironmentFile=%{_sysconfdir}/sysconfig/step-ca
-ExecStart=%{_bindir}/step-ca --pidfile "%{_rundir}/step-ca/step-ca.pid" "\${STEPPATH}/config/ca.json"
+ExecStart=%{_bindir}/step-ca "\${STEPPATH}/config/ca.json"
 KillMode=process
 Restart=on-failure
 RestartSec=30s
@@ -118,6 +122,7 @@ export CI=true
 %license LICENSE
 %{_bindir}/step-ca
 %{_unitdir}/step-ca.service
+%{_usr}/lib/tmpfiles.d/step-ca.conf
 %config(noreplace) %{_sysconfdir}/sysconfig/step-ca
 %defattr(-, %{step_ca_user}, %{step_ca_group}, -)
 %dir %{_rundir}/step-ca

--- a/SPECS/el9/step-ca.spec
+++ b/SPECS/el9/step-ca.spec
@@ -34,6 +34,7 @@ cd %{_builddir}/certificates-%{version}
 %install
 %{__install} -d -m 0755 \
  %{buildroot}%{_bindir} \
+ %{buildroot}%{_rundir}/step-ca \
  %{buildroot}%{_sysconfdir}/sysconfig \
  %{buildroot}%{_unitdir}
 %{__install} -d -m 0700 %{buildroot}%{step_ca_home}
@@ -56,7 +57,7 @@ After=basic.target network.target
 User=%{step_ca_user}
 Group=%{step_ca_group}
 EnvironmentFile=%{_sysconfdir}/sysconfig/step-ca
-ExecStart=%{_bindir}/step-ca "\${STEPPATH}/config/ca.json"
+ExecStart=%{_bindir}/step-ca --pidfile "%{_rundir}/step-ca/step-ca.pid" "\${STEPPATH}/config/ca.json"
 KillMode=process
 Restart=on-failure
 RestartSec=30s
@@ -119,6 +120,7 @@ export CI=true
 %{_unitdir}/step-ca.service
 %config(noreplace) %{_sysconfdir}/sysconfig/step-ca
 %defattr(-, %{step_ca_user}, %{step_ca_group}, -)
+%dir %{_rundir}/step-ca
 %dir %{step_ca_home}
 
 

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -232,10 +232,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.23.1-1
+      version: &step_ca_version 0.23.2-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.23.1-1
+      version: &step_cli_version 0.23.2-1
     tbb:
       image: rpmbuild-tbb
       version: &tbb_version 2020.3-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -193,10 +193,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.23.1-1
+      version: &step_ca_version 0.23.2-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.23.1-1
+      version: &step_cli_version 0.23.2-1
     wal-g:
       image: rpmbuild-wal-g
       version: &walg_version 2.0.1-1

--- a/docker/el7/Dockerfile.rpmbuild-go
+++ b/docker/el7/Dockerfile.rpmbuild-go
@@ -3,8 +3,8 @@ ARG rpmbuild_image=rpmbuild-generic
 ARG rpmbuild_image_prefix
 # hadolint ignore=DL3007
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
-ARG go_version=1.19.5
-ARG go_checksum=36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95
+ARG go_version=1.20.1
+ARG go_checksum=000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02
 ARG packages
 
 ENV GOPATH=${RPMBUILD_HOME}/go

--- a/docker/el9/Dockerfile.rpmbuild-go
+++ b/docker/el9/Dockerfile.rpmbuild-go
@@ -3,8 +3,8 @@ ARG rpmbuild_image=rpmbuild-generic
 ARG rpmbuild_image_prefix
 # hadolint ignore=DL3007
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
-ARG go_version=1.19.5
-ARG go_checksum=36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95
+ARG go_version=1.20.1
+ARG go_checksum=000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02
 ARG packages
 
 ENV GOPATH=${RPMBUILD_HOME}/go


### PR DESCRIPTION
https://github.com/smallstep/certificates/compare/v0.23.1...v0.23.2
https://github.com/smallstep/cli/compare/v0.23.1...v0.23.2

As far as I can tell, we do not use any of the removed CLI utils.
I.E.:
> - The deprecated CLI utils `step-awskms-init`, `step-cloudkms-init`, `step-pkcs11-init`, `step-yubikey-init` have been removed.