### PR TITLE
Upgrade armadillo from v11.4.4 to v12.0.1 (EL9)

### DIFF
--- a/SPECS/el9/armadillo.spec
+++ b/SPECS/el9/armadillo.spec
@@ -66,7 +66,7 @@ and user documentation (API reference guide).
 
 
 %files
-%{_libdir}/libarmadillo.so.11*
+%{_libdir}/libarmadillo.so.12*
 %license LICENSE.txt NOTICE.txt
 
 %files devel

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -54,7 +54,7 @@ x-rpmbuild:
         _smp_ncpus_max: 4
     armadillo:
       image: rpmbuild-armadillo
-      version: &armadillo_version 11.4.4-1
+      version: &armadillo_version 12.0.1-1
     gdal:
       image: rpmbuild-gdal
       version: &gdal_version 3.6.2-1


### PR DESCRIPTION
https://arma.sourceforge.net/download.html

We might want to hold off on this until we upgrade GDAL again