### PR TITLE
update to java 11

### DIFF
--- a/SPECS/el7/sbt.spec
+++ b/SPECS/el7/sbt.spec
@@ -14,8 +14,8 @@ Source3:        sbt.gpg
 
 
 Requires:       apache-ivy
-Requires:       java-1.8.0-openjdk
-Requires:       java-1.8.0-openjdk-devel
+Requires:       java-11-openjdk-devel
+Requires:       java-11-openjdk
 
 
 %description


### PR DESCRIPTION
I'm working through a MapRoulette  upstream merge and it seems like we will need to use java 11