### PR TITLE
Use default version of `java-openjdk` (EL9)

### DIFF
--- a/SPECS/el9/osmosis.spec
+++ b/SPECS/el9/osmosis.spec
@@ -7,7 +7,7 @@ License:        LGPLv3 and Public Domain
 URL:            https://github.com/openstreetmap/osmosis
 
 BuildArch:      noarch
-Requires:       java-1.8.0-openjdk
+Requires:       java-openjdk
 
 Source0:        https://github.com/openstreetmap/osmosis/releases/download/%{version}/osmosis-%{version}.tgz
 

--- a/SPECS/el9/sbt.spec
+++ b/SPECS/el9/sbt.spec
@@ -14,8 +14,8 @@ Source3:        sbt.gpg
 
 
 Requires:       apache-ivy
-Requires:       java-1.8.0-openjdk
-Requires:       java-1.8.0-openjdk-devel
+Requires:       java-openjdk
+Requires:       java-openjdk-devel
 
 
 %description

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -121,7 +121,7 @@ x-rpmbuild:
         libosmium_min_version: *libosmium_min_version
     osmosis:
       image: rpmbuild-generic
-      version: &osmosis_version 0.48.3-1
+      version: &osmosis_version 0.48.3-2
       arch: noarch
     osmium-tool:
       image: rpmbuild-osmium-tool
@@ -172,7 +172,7 @@ x-rpmbuild:
       version: &rubygem_libxml_ruby_version 4.0.0-1
     sbt:
       image: rpmbuild-generic
-      version: &sbt_version 1.8.2-1
+      version: &sbt_version 1.8.2-2
       arch: noarch
     spawn-fcgi:
       image: rpmbuild-generic


### PR DESCRIPTION
I must have missed this when I combined `EL7` & `EL9` into one branch in https://github.com/radiant-maxar/geoint-deps/pull/53