### PR TITLE
Use default version of `java-openjdk` (EL7)

### DIFF
--- a/SPECS/el7/osmosis.spec
+++ b/SPECS/el7/osmosis.spec
@@ -7,7 +7,7 @@ License:        LGPLv3 and Public Domain
 URL:            https://github.com/openstreetmap/osmosis
 
 BuildArch:      noarch
-Requires:       java-1.8.0-openjdk
+Requires:       java-openjdk
 
 Source0:        https://github.com/openstreetmap/osmosis/releases/download/%{version}/osmosis-%{version}.tgz
 

--- a/SPECS/el7/sbt.spec
+++ b/SPECS/el7/sbt.spec
@@ -14,8 +14,8 @@ Source3:        sbt.gpg
 
 
 Requires:       apache-ivy
-Requires:       java-1.8.0-openjdk
-Requires:       java-1.8.0-openjdk-devel
+Requires:       java-openjdk
+Requires:       java-openjdk-devel
 
 
 %description


### PR DESCRIPTION
Do the same for EL7 as was done for EL9 in https://github.com/radiant-maxar/geoint-deps/pull/130