### PR TITLE
GEOS 3.11.2 on EL9

### DIFF
--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -63,7 +63,7 @@ x-rpmbuild:
         proj_min_version: *proj_min_version
     geos:
       image: rpmbuild-generic
-      version: &geos_version 3.11.1-1
+      version: &geos_version 3.11.2-1
     g2clib:
       image: rpmbuild-g2clib
       name: g2clib-devel


### PR DESCRIPTION
Upgrade [GEOS to the 3.11.2](https://github.com/libgeos/geos/releases/tag/3.11.2), a bugfix release.