### PR TITLE
Smallstep CA 0.24.0 and CLI 0.24.1

### DIFF
--- a/Makefile.el7
+++ b/Makefile.el7
@@ -186,6 +186,7 @@ distclean: .env
 	echo RPMBUILD_SFCGAL_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/SFCGAL.spec) >> .env
 	echo RPMBUILD_SQLITE_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/sqlite.spec) >> .env
 	echo RPMBUILD_SQLITE_PCRE_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/sqlite-pcre.spec) >> .env
+	echo RPMBUILD_STEP_CA_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/step-ca.spec) >> .env
 	echo RPMBUILD_TBB_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/tbb.spec) >> .env
 	echo RPMBUILD_WALG_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/wal-g.spec --define postgres_version=$(POSTGRES_VERSION)) >> .env
 

--- a/Makefile.el9
+++ b/Makefile.el9
@@ -164,6 +164,7 @@ distclean: .env
 	echo RPMBUILD_RUBYGEM_LIBXML_RUBY_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/rubygem-libxml-ruby.spec) >> .env
 	echo RPMBUILD_SFCGAL_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/SFCGAL.spec) >> .env
 	echo RPMBUILD_SQLITE_PCRE_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/sqlite-pcre.spec) >> .env
+	echo RPMBUILD_STEP_CA_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/step-ca.spec) >> .env
 	echo RPMBUILD_WALG_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/wal-g.spec --define postgres_version=$(POSTGRES_VERSION)) >> .env
 
 

--- a/SPECS/el7/step-ca.spec
+++ b/SPECS/el7/step-ca.spec
@@ -12,6 +12,9 @@ License:        ASL 2.0
 URL:            https://github.com/smallstep/certificates
 Source0:        https://github.com/smallstep/certificates/archive/v%{version}/certificates-%{version}.tar.gz
 
+BuildRequires:  git
+BuildRequires:  openssl-devel
+
 
 %description
 A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH.

--- a/SPECS/el7/step-cli.spec
+++ b/SPECS/el7/step-cli.spec
@@ -7,6 +7,8 @@ License:        ASL 2.0
 URL:            https://github.com/smallstep/cli
 Source0:        https://github.com/smallstep/cli/archive/v%{version}/cli-%{version}.tar.gz
 
+BuildRequires:  git
+
 
 %description
 step is an easy-to-use CLI tool for building, operating, and automating Public Key Infrastructure (PKI) systems and workflows. It's the client counterpart to the step-ca online Certificate Authority (CA). You can use it for many common crypto and X.509 operations—either independently, or with an online CA

--- a/SPECS/el9/step-ca.spec
+++ b/SPECS/el9/step-ca.spec
@@ -12,6 +12,9 @@ License:        ASL 2.0
 URL:            https://github.com/smallstep/certificates
 Source0:        https://github.com/smallstep/certificates/archive/v%{version}/certificates-%{version}.tar.gz
 
+BuildRequires:  git
+BuildRequires:  openssl-devel
+
 
 %description
 A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH.

--- a/SPECS/el9/step-cli.spec
+++ b/SPECS/el9/step-cli.spec
@@ -7,6 +7,8 @@ License:        ASL 2.0
 URL:            https://github.com/smallstep/cli
 Source0:        https://github.com/smallstep/cli/archive/v%{version}/cli-%{version}.tar.gz
 
+BuildRequires:  git
+
 
 %description
 step is an easy-to-use CLI tool for building, operating, and automating Public Key Infrastructure (PKI) systems and workflows. It's the client counterpart to the step-ca online Certificate Authority (CA). You can use it for many common crypto and X.509 operations—either independently, or with an online CA

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -226,10 +226,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.23.2-1
+      version: &step_ca_version 0.24.0-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.23.2-1
+      version: &step_cli_version 0.24.1-1
     tbb:
       image: rpmbuild-tbb
       version: &tbb_version 2020.3-1

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -547,6 +547,7 @@ services:
       <<: *build_defaults
       args:
         <<: *build_args_defaults
+        packages: ${RPMBUILD_STEP_CA_PACKAGES}
         rpmbuild_image: rpmbuild-generic
       dockerfile: docker/el7/Dockerfile.rpmbuild-go
   rpmbuild-tbb:

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -182,10 +182,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.23.2-1
+      version: &step_ca_version 0.24.0-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.23.2-1
+      version: &step_cli_version 0.24.1-1
     wal-g:
       image: rpmbuild-wal-g
       version: &walg_version 2.0.1-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -433,6 +433,7 @@ services:
       <<: *build_defaults
       args:
         <<: *build_args_defaults
+        packages: ${RPMBUILD_STEP_CA_PACKAGES}
         rpmbuild_image: rpmbuild-generic
       dockerfile: docker/el9/Dockerfile.rpmbuild-go
   rpmbuild-wal-g:

--- a/docker/el7/Dockerfile.rpmbuild-go
+++ b/docker/el7/Dockerfile.rpmbuild-go
@@ -3,8 +3,8 @@ ARG rpmbuild_image=rpmbuild-generic
 ARG rpmbuild_image_prefix
 # hadolint ignore=DL3007
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
-ARG go_version=1.20.1
-ARG go_checksum=000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02
+ARG go_version=1.20.3
+ARG go_checksum=979694c2c25c735755bf26f4f45e19e64e4811d661dd07b8c010f7a8e18adfca
 ARG packages
 
 ENV GOPATH=${RPMBUILD_HOME}/go

--- a/docker/el9/Dockerfile.rpmbuild-go
+++ b/docker/el9/Dockerfile.rpmbuild-go
@@ -3,8 +3,8 @@ ARG rpmbuild_image=rpmbuild-generic
 ARG rpmbuild_image_prefix
 # hadolint ignore=DL3007
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
-ARG go_version=1.20.1
-ARG go_checksum=000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02
+ARG go_version=1.20.3
+ARG go_checksum=979694c2c25c735755bf26f4f45e19e64e4811d661dd07b8c010f7a8e18adfca
 ARG packages
 
 ENV GOPATH=${RPMBUILD_HOME}/go


### PR DESCRIPTION
* Upgrade Smallstep [CA to 0.24.0](https://github.com/smallstep/certificates/blob/master/CHANGELOG.md#v0240---2023-04-12) and [CLI to 0.24.1](https://github.com/smallstep/cli/blob/master/CHANGELOG.md#v0241---2022-04-12).
* Upgrade Go compiler to 1.20.3.