### PR TITLE
Caddy

### DIFF
--- a/.github/workflows/ci.el7.yml
+++ b/.github/workflows/ci.el7.yml
@@ -62,6 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         rpm:
+          - caddy
           - CGAL
           - dumb-init
           - FileGDBAPI

--- a/.github/workflows/ci.el9.yml
+++ b/.github/workflows/ci.el9.yml
@@ -62,6 +62,7 @@ jobs:
       matrix:
         rpm:
           - armadillo
+          - caddy
           - CGAL
           - FileGDBAPI
           - g2clib

--- a/Makefile.el7
+++ b/Makefile.el7
@@ -39,6 +39,7 @@ RPMBUILD_UID := $(shell id -u)
 RPMBUILD_GID := $(shell id -g)
 
 # RPM files at desired versions.
+CADDY_RPM := $(call rpm_file,caddy)
 CGAL_RPM := $(call rpm_file,CGAL)
 DUMB_INIT_RPM := $(call rpm_file,dumb-init)
 FILEGDBAPI_RPM := $(call rpm_file,FileGDBAPI)
@@ -87,6 +88,7 @@ RPMBUILD_BASE_IMAGES := \
 	rpmbuild-pgdg
 RPMBUILD_RPMS := \
 	CGAL \
+	caddy \
 	dumb-init \
 	FileGDBAPI \
 	gdal \
@@ -214,6 +216,7 @@ rpmbuild-pgdg: rpmbuild
 
 ## RPM targets
 CGAL: $(CGAL_RPM)
+caddy: $(CADDY_RPM)
 dumb-init: $(DUMB_INIT_RPM)
 FileGDBAPI: $(FILEGDBAPI_RPM)
 gdal: $(CGAL_RPM) $(FILEGDBAPI_RPM) $(GEOS_RPM) $(GPSBABEL_RPM) $(LIBKML_RPM) $(OGDI_RPM) $(SQLITE_RPM) \

--- a/Makefile.el9
+++ b/Makefile.el9
@@ -40,6 +40,7 @@ RPMBUILD_GID := $(shell id -g)
 
 # RPM files at desired versions.
 ARMADILLO_RPM := $(call rpm_file,armadillo)
+CADDY_RPM := $(call rpm_file,caddy)
 CGAL_RPM := $(call rpm_file,CGAL)
 FILEGDBAPI_RPM := $(call rpm_file,FileGDBAPI)
 G2CLIB_RPM := $(call rpm_file,g2clib)
@@ -78,6 +79,7 @@ RPMBUILD_BASE_IMAGES := \
 	rpmbuild-pgdg
 RPMBUILD_RPMS := \
 	armadillo \
+	caddy \
 	CGAL \
 	FileGDBAPI \
 	g2clib \
@@ -193,6 +195,7 @@ rpmbuild-pgdg: rpmbuild
 armadillo: $(ARMADILLO_RPM)
 CGAL: $(CGAL_RPM)
 FileGDBAPI: $(FILEGDBAPI_RPM)
+caddy: $(CADDY_RPM)
 g2clib: $(G2CLIB_RPM)
 gdal: $(ARMADILLO_RPM) $(CGAL_RPM) $(FILEGDBAPI_RPM) $(G2CLIB_RPM) $(GEOS_RPM) $(PROJ_RPM) \
       $(LIBGEOTIFF_RPM) $(SFCGAL_RPM) \

--- a/SOURCES/el7/caddy-no-binary-mods.patch
+++ b/SOURCES/el7/caddy-no-binary-mods.patch
@@ -1,0 +1,45 @@
+diff --git a/cmd/commands.go b/cmd/commands.go
+index 9216b898..80fc82fe 100644
+--- a/cmd/commands.go
++++ b/cmd/commands.go
+@@ -347,40 +347,6 @@ latest versions. EXPERIMENTAL: May be changed or removed.`,
+ 		}(),
+ 	})
+ 
+-	RegisterCommand(Command{
+-		Name:  "add-package",
+-		Func:  cmdAddPackage,
+-		Usage: "<packages...>",
+-		Short: "Adds Caddy packages (EXPERIMENTAL)",
+-		Long: `
+-Downloads an updated Caddy binary with the specified packages (module/plugin)
+-added. Retains existing packages. Returns an error if the any of packages are 
+-already included. EXPERIMENTAL: May be changed or removed.
+-`,
+-		Flags: func() *flag.FlagSet {
+-			fs := flag.NewFlagSet("add-package", flag.ExitOnError)
+-			fs.Bool("keep-backup", false, "Keep the backed up binary, instead of deleting it")
+-			return fs
+-		}(),
+-	})
+-
+-	RegisterCommand(Command{
+-		Name:  "remove-package",
+-		Func:  cmdRemovePackage,
+-		Usage: "<packages...>",
+-		Short: "Removes Caddy packages (EXPERIMENTAL)",
+-		Long: `
+-Downloads an updated Caddy binaries without the specified packages (module/plugin). 
+-Returns an error if any of the packages are not included. 
+-EXPERIMENTAL: May be changed or removed.
+-`,
+-		Flags: func() *flag.FlagSet {
+-			fs := flag.NewFlagSet("remove-package", flag.ExitOnError)
+-			fs.Bool("keep-backup", false, "Keep the backed up binary, instead of deleting it")
+-			return fs
+-		}(),
+-	})
+-
+ 	RegisterCommand(Command{
+ 		Name: "manpage",
+ 		Func: func(fl Flags) (int, error) {

--- a/SOURCES/el9/caddy-no-binary-mods.patch
+++ b/SOURCES/el9/caddy-no-binary-mods.patch
@@ -1,0 +1,45 @@
+diff --git a/cmd/commands.go b/cmd/commands.go
+index 9216b898..80fc82fe 100644
+--- a/cmd/commands.go
++++ b/cmd/commands.go
+@@ -347,40 +347,6 @@ latest versions. EXPERIMENTAL: May be changed or removed.`,
+ 		}(),
+ 	})
+ 
+-	RegisterCommand(Command{
+-		Name:  "add-package",
+-		Func:  cmdAddPackage,
+-		Usage: "<packages...>",
+-		Short: "Adds Caddy packages (EXPERIMENTAL)",
+-		Long: `
+-Downloads an updated Caddy binary with the specified packages (module/plugin)
+-added. Retains existing packages. Returns an error if the any of packages are 
+-already included. EXPERIMENTAL: May be changed or removed.
+-`,
+-		Flags: func() *flag.FlagSet {
+-			fs := flag.NewFlagSet("add-package", flag.ExitOnError)
+-			fs.Bool("keep-backup", false, "Keep the backed up binary, instead of deleting it")
+-			return fs
+-		}(),
+-	})
+-
+-	RegisterCommand(Command{
+-		Name:  "remove-package",
+-		Func:  cmdRemovePackage,
+-		Usage: "<packages...>",
+-		Short: "Removes Caddy packages (EXPERIMENTAL)",
+-		Long: `
+-Downloads an updated Caddy binaries without the specified packages (module/plugin). 
+-Returns an error if any of the packages are not included. 
+-EXPERIMENTAL: May be changed or removed.
+-`,
+-		Flags: func() *flag.FlagSet {
+-			fs := flag.NewFlagSet("remove-package", flag.ExitOnError)
+-			fs.Bool("keep-backup", false, "Keep the backed up binary, instead of deleting it")
+-			return fs
+-		}(),
+-	})
+-
+ 	RegisterCommand(Command{
+ 		Name: "manpage",
+ 		Func: func(fl Flags) (int, error) {

--- a/SPECS/el7/caddy.spec
+++ b/SPECS/el7/caddy.spec
@@ -30,6 +30,8 @@ cd %{_builddir}/caddy-%{version}
 
 
 %build
+export CGO_CFLAGS="%{optflags}"
+export CGO_LDFLAGS="%{?build_ldflags}"
 %{__mkdir_p} caddy@%{version}
 %{__install} cmd/caddy/main.go caddy@%{version}
 pushd caddy@%{version}
@@ -115,6 +117,8 @@ EOF
 
 
 %check
+export CGO_CFLAGS="%{optflags}"
+export CGO_LDFLAGS="%{?build_ldflags}"
 go get -v
 pushd cmd/caddy
 go build -v

--- a/SPECS/el7/caddy.spec
+++ b/SPECS/el7/caddy.spec
@@ -13,7 +13,7 @@ Summary:        Fast and extensible multi-platform HTTP/1-2-3 web server with au
 License:        ASL 2.0 and MIT and BSD
 URL:            https://github.com/caddyserver/caddy
 Source0:        https://github.com/caddyserver/caddy/archive/v%{version}/caddy-%{version}.tar.gz
-Source1:        caddy-no-binary-mods.patch
+Patch0:         caddy-no-binary-mods.patch
 
 BuildRequires:  git
 
@@ -23,12 +23,12 @@ Caddy is a powerful, extensible platform to serve your sites, services, and apps
 
 
 %prep
-%autosetup
+%autosetup -N
 cd "${HOME}"
 %{__rm} -fr %{_builddir}/caddy-%{version}
 %{__git} clone --single-branch -b v%{version} %{url} %{_builddir}/caddy-%{version}
 cd %{_builddir}/caddy-%{version}
-%{__patch} -p1 < %{SOURCE1}
+%autopatch -p1
 
 
 %build

--- a/SPECS/el7/caddy.spec
+++ b/SPECS/el7/caddy.spec
@@ -10,9 +10,10 @@ Name:           caddy
 Version:        %{rpmbuild_version}
 Release:        %{rpmbuild_release}%{?dist}
 Summary:        Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
-License:        ASL 2.0
+License:        ASL 2.0 and MIT and BSD
 URL:            https://github.com/caddyserver/caddy
 Source0:        https://github.com/caddyserver/caddy/archive/v%{version}/caddy-%{version}.tar.gz
+Source1:        caddy-no-binary-mods.patch
 
 BuildRequires:  git
 
@@ -22,11 +23,12 @@ Caddy is a powerful, extensible platform to serve your sites, services, and apps
 
 
 %prep
-%autosetup -n caddy-%{version}
+%autosetup
 cd "${HOME}"
 %{__rm} -fr %{_builddir}/caddy-%{version}
 %{__git} clone --single-branch -b v%{version} %{url} %{_builddir}/caddy-%{version}
 cd %{_builddir}/caddy-%{version}
+%{__patch} -p1 < %{SOURCE1}
 
 
 %build

--- a/SPECS/el7/caddy.spec
+++ b/SPECS/el7/caddy.spec
@@ -1,0 +1,159 @@
+%global caddy_config %{_sysconfdir}/caddy
+%global caddy_home %{_sharedstatedir}/caddy
+%global caddy_user caddy
+%global caddy_group %{caddy_user}
+%global caddy_uid 517
+%global caddy_gid %{caddy_uid}
+
+Name:           caddy
+Version:        %{rpmbuild_version}
+Release:        %{rpmbuild_release}%{?dist}
+Summary:        Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
+License:        ASL 2.0
+URL:            https://github.com/caddyserver/caddy
+Source0:        https://github.com/caddyserver/caddy/archive/v%{version}/caddy-%{version}.tar.gz
+
+BuildRequires:  git
+
+%description
+Caddy is a powerful, extensible platform to serve your sites, services, and apps, written in Go.
+
+
+%prep
+%autosetup -n caddy-%{version}
+cd "${HOME}"
+%{__rm} -fr %{_builddir}/caddy-%{version}
+%{__git} clone --single-branch -b v%{version} %{url} %{_builddir}/caddy-%{version}
+cd %{_builddir}/caddy-%{version}
+
+
+%build
+%{__mkdir_p} caddy@%{version}
+%{__install} cmd/caddy/main.go caddy@%{version}
+pushd caddy@%{version}
+go mod init caddy
+go get -v
+go build -v
+popd
+
+
+%install
+%{__install} -d -m 0755 \
+ %{buildroot}%{_bindir} \
+ %{buildroot}%{_sysconfdir}/sysconfig \
+ %{buildroot}%{_unitdir} \
+ %{buildroot}%{_usr}/lib/tmpfiles.d
+%{__install} -d -m 0750 \
+ %{buildroot}%{caddy_home} \
+ %{buildroot}%{_rundir}/caddy \
+ %{buildroot}%{caddy_config}
+%{__install} -p caddy@%{version}/caddy %{buildroot}%{_bindir}
+echo "d %{_rundir}/%{name} 0750 %{caddy_user} %{caddy_group} -" > \
+     %{buildroot}%{_usr}/lib/tmpfiles.d/caddy.conf
+
+# Configuration files.
+touch %{buildroot}%{_sysconfdir}/sysconfig/caddy \
+      %{buildroot}%{caddy_config}/Caddyfile
+chmod 0750 %{buildroot}%{_sysconfdir}/sysconfig/caddy
+
+# Unit files.
+cat <<EOF > %{buildroot}%{_unitdir}/caddy.service
+[Unit]
+Description=Caddy
+Documentation=https://caddyserver.com/docs/
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Type=notify
+User=%{caddy_user}
+Group=%{caddy_group}
+EnvironmentFile=%{_sysconfdir}/sysconfig/caddy
+ExecStart=%{_bindir}/caddy run --environ --config %{caddy_config}/Caddyfile
+ExecReload=%{_bindir}/caddy reload --config %{caddy_config}/Caddyfile --force
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+LimitNPROC=512
+PrivateTmp=true
+ProtectSystem=full
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF > %{buildroot}%{_unitdir}/caddy-api.service
+[Unit]
+Description=Caddy
+Documentation=https://caddyserver.com/docs/
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Type=notify
+User=%{caddy_user}
+Group=%{caddy_group}
+EnvironmentFile=%{_sysconfdir}/sysconfig/caddy
+ExecStart=%{_bindir}/caddy run --environ --resume
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+LimitNPROC=512
+PrivateTmp=true
+ProtectSystem=full
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+
+%check
+go get -v
+pushd cmd/caddy
+go build -v
+popd
+go test -v
+
+
+%pre
+%{_bindir}/getent group %{caddy_group} >/dev/null || \
+    groupadd \
+        --force \
+        --gid %{caddy_gid} \
+        --system \
+        %{caddy_group}
+
+%{_bindir}/getent passwd %{caddy_user} >/dev/null || \
+    useradd \
+        --uid %{caddy_uid} \
+        --gid %{caddy_group} \
+        --comment "Caddy web user" \
+        --shell %{_sbindir}/nologin \
+        --home-dir %{caddy_home} \
+        --no-create-home \
+        --system \
+        %{caddy_user}
+
+
+%post
+%{_sbindir}/setcap cap_net_bind_service=+ep %{_bindir}/caddy
+
+
+%files
+%doc AUTHORS README.md
+%license LICENSE
+%{_bindir}/caddy
+%{_unitdir}/caddy.service
+%{_unitdir}/caddy-api.service
+%{_usr}/lib/tmpfiles.d/caddy.conf
+%defattr(-, root, %{caddy_group}, -)
+%config(noreplace) %{caddy_config}/Caddyfile
+%config(noreplace) %{_sysconfdir}/sysconfig/caddy
+%defattr(-, %{caddy_user}, %{caddy_group}, -)
+%dir %{_rundir}/caddy
+%dir %{caddy_home}
+
+
+%changelog
+* %(%{_bindir}/date "+%%a %%b %%d %%Y") %{rpmbuild_name} <%{rpmbuild_email}> - %{version}-%{rpmbuild_release}
+- %{version}-%{rpmbuild_release}

--- a/SPECS/el7/caddy.spec
+++ b/SPECS/el7/caddy.spec
@@ -1,5 +1,6 @@
 %global caddy_config %{_sysconfdir}/caddy
 %global caddy_home %{_sharedstatedir}/caddy
+%global caddy_run %{_rundir}/caddy
 %global caddy_user caddy
 %global caddy_group %{caddy_user}
 %global caddy_uid 517
@@ -14,6 +15,7 @@ URL:            https://github.com/caddyserver/caddy
 Source0:        https://github.com/caddyserver/caddy/archive/v%{version}/caddy-%{version}.tar.gz
 
 BuildRequires:  git
+
 
 %description
 Caddy is a powerful, extensible platform to serve your sites, services, and apps, written in Go.
@@ -45,16 +47,21 @@ popd
  %{buildroot}%{_usr}/lib/tmpfiles.d
 %{__install} -d -m 0750 \
  %{buildroot}%{caddy_home} \
- %{buildroot}%{_rundir}/caddy \
+ %{buildroot}%{caddy_run} \
  %{buildroot}%{caddy_config}
 %{__install} -p caddy@%{version}/caddy %{buildroot}%{_bindir}
-echo "d %{_rundir}/%{name} 0750 %{caddy_user} %{caddy_group} -" > \
+echo "d %{caddy_run} 0750 %{caddy_user} %{caddy_group} -" > \
      %{buildroot}%{_usr}/lib/tmpfiles.d/caddy.conf
 
 # Configuration files.
-touch %{buildroot}%{_sysconfdir}/sysconfig/caddy \
-      %{buildroot}%{caddy_config}/Caddyfile
-chmod 0750 %{buildroot}%{_sysconfdir}/sysconfig/caddy
+echo "{}" > %{buildroot}%{caddy_config}/config.json
+touch %{buildroot}%{caddy_config}/Caddyfile
+
+# Environment file.
+cat <<EOF > %{buildroot}%{_sysconfdir}/sysconfig/%{name}
+CADDY_CONFIG_FILE=%{caddy_config}/Caddyfile
+EOF
+chmod 0750 %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 
 # Unit files.
 cat <<EOF > %{buildroot}%{_unitdir}/%{name}.service
@@ -68,9 +75,9 @@ Requires=network-online.target
 Type=notify
 User=%{caddy_user}
 Group=%{caddy_group}
-EnvironmentFile=%{_sysconfdir}/sysconfig/caddy
-ExecStart=%{_bindir}/caddy run --environ --config %{caddy_config}/Caddyfile
-ExecReload=%{_bindir}/caddy reload --config %{caddy_config}/Caddyfile --force
+EnvironmentFile=%{_sysconfdir}/sysconfig/%{name}
+ExecStart=%{_bindir}/caddy run --environ --config \${CADDY_CONFIG_FILE}
+ExecReload=%{_bindir}/caddy reload --config \${CADDY_CONFIG_FILE} --force
 TimeoutStopSec=5s
 LimitNOFILE=1048576
 LimitNPROC=512
@@ -93,7 +100,7 @@ Requires=network-online.target
 Type=notify
 User=%{caddy_user}
 Group=%{caddy_group}
-EnvironmentFile=%{_sysconfdir}/sysconfig/caddy
+EnvironmentFile=%{_sysconfdir}/sysconfig/%{name}
 ExecStart=%{_bindir}/caddy run --environ --resume
 TimeoutStopSec=5s
 LimitNOFILE=1048576
@@ -163,9 +170,10 @@ if test -f /.dockerenv; then exit 0; fi
 %{_usr}/lib/tmpfiles.d/caddy.conf
 %defattr(-, root, %{caddy_group}, -)
 %config(noreplace) %{caddy_config}/Caddyfile
-%config(noreplace) %{_sysconfdir}/sysconfig/caddy
+%config(noreplace) %{caddy_config}/config.json
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %defattr(-, %{caddy_user}, %{caddy_group}, -)
-%dir %{_rundir}/caddy
+%dir %{caddy_run}
 %dir %{caddy_home}
 
 

--- a/SPECS/el7/step-ca.spec
+++ b/SPECS/el7/step-ca.spec
@@ -55,7 +55,7 @@ STEPPATH=%{_sharedstatedir}/step-ca
 EOF
 
 # Unit file.
-cat <<EOF > %{buildroot}%{_unitdir}/step-ca.service
+cat <<EOF > %{buildroot}%{_unitdir}/%{name}.service
 [Unit]
 Description=step-ca
 After=basic.target network.target
@@ -86,23 +86,38 @@ EOF
 
 
 %pre
-getent group %{step_ca_group} >/dev/null || \
-    groupadd \
+%{_bindir}/getent group %{step_ca_group} >/dev/null || \
+    %{_sbindir}/groupadd \
         --force \
         --gid %{step_ca_gid} \
         --system \
         %{step_ca_group}
 
-getent passwd %{step_ca_user} >/dev/null || \
-    useradd \
+%{_bindir}/getent passwd %{step_ca_user} >/dev/null || \
+    %{_sbindir}/useradd \
         --uid %{step_ca_uid} \
         --gid %{step_ca_group} \
         --comment "Smallstep CA User" \
-        --shell /sbin/nologin \
+        --shell %{_sbindir}/nologin \
         --home-dir %{step_ca_home} \
         --no-create-home \
         --system \
         %{step_ca_user}
+
+
+%post
+if test -f /.dockerenv; then exit 0; fi
+%systemd_post %{name}.service
+
+
+%preun
+if test -f /.dockerenv; then exit 0; fi
+%systemd_preun %{name}.service
+
+
+%postun
+if test -f /.dockerenv; then exit 0; fi
+%systemd_postun %{name}.service
 
 
 %check
@@ -114,7 +129,7 @@ export CI=true
 %doc CHANGELOG.md README.md
 %license LICENSE
 %{_bindir}/step-ca
-%{_unitdir}/step-ca.service
+%{_unitdir}/%{name}.service
 %{_usr}/lib/tmpfiles.d/step-ca.conf
 %config(noreplace) %{_sysconfdir}/sysconfig/step-ca
 %defattr(-, %{step_ca_user}, %{step_ca_group}, -)

--- a/SPECS/el7/step-ca.spec
+++ b/SPECS/el7/step-ca.spec
@@ -106,6 +106,7 @@ EOF
 
 
 %post
+%{_sbindir}/setcap cap_net_bind_service=+ep %{_bindir}/step-ca
 if test -f /.dockerenv; then exit 0; fi
 %systemd_post %{name}.service
 

--- a/SPECS/el9/caddy.spec
+++ b/SPECS/el9/caddy.spec
@@ -10,9 +10,10 @@ Name:           caddy
 Version:        %{rpmbuild_version}
 Release:        %{rpmbuild_release}%{?dist}
 Summary:        Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
-License:        ASL 2.0
+License:        ASL 2.0 and MIT and BSD
 URL:            https://github.com/caddyserver/caddy
 Source0:        https://github.com/caddyserver/caddy/archive/v%{version}/caddy-%{version}.tar.gz
+Source1:        caddy-no-binary-mods.patch
 
 BuildRequires:  git
 BuildRequires:  systemd-rpm-macros
@@ -23,11 +24,12 @@ Caddy is a powerful, extensible platform to serve your sites, services, and apps
 
 
 %prep
-%autosetup -n caddy-%{version}
+%autosetup
 cd "${HOME}"
 %{__rm} -fr %{_builddir}/caddy-%{version}
 %{__git} clone --single-branch -b v%{version} %{url} %{_builddir}/caddy-%{version}
 cd %{_builddir}/caddy-%{version}
+%{__patch} -p1 < %{SOURCE1}
 
 
 %build

--- a/SPECS/el9/caddy.spec
+++ b/SPECS/el9/caddy.spec
@@ -14,6 +14,8 @@ URL:            https://github.com/caddyserver/caddy
 Source0:        https://github.com/caddyserver/caddy/archive/v%{version}/caddy-%{version}.tar.gz
 
 BuildRequires:  git
+BuildRequires:  systemd-rpm-macros
+
 
 %description
 Caddy is a powerful, extensible platform to serve your sites, services, and apps, written in Go.
@@ -57,7 +59,7 @@ touch %{buildroot}%{_sysconfdir}/sysconfig/caddy \
 chmod 0750 %{buildroot}%{_sysconfdir}/sysconfig/caddy
 
 # Unit files.
-cat <<EOF > %{buildroot}%{_unitdir}/caddy.service
+cat <<EOF > %{buildroot}%{_unitdir}/%{name}.service
 [Unit]
 Description=Caddy
 Documentation=https://caddyserver.com/docs/
@@ -82,7 +84,7 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 WantedBy=multi-user.target
 EOF
 
-cat <<EOF > %{buildroot}%{_unitdir}/caddy-api.service
+cat <<EOF > %{buildroot}%{_unitdir}/%{name}-api.service
 [Unit]
 Description=Caddy
 Documentation=https://caddyserver.com/docs/
@@ -117,14 +119,14 @@ go test -v
 
 %pre
 %{_bindir}/getent group %{caddy_group} >/dev/null || \
-    groupadd \
+    %{_sbindir}/groupadd \
         --force \
         --gid %{caddy_gid} \
         --system \
         %{caddy_group}
 
 %{_bindir}/getent passwd %{caddy_user} >/dev/null || \
-    useradd \
+    %{_sbindir}/useradd \
         --uid %{caddy_uid} \
         --gid %{caddy_group} \
         --comment "Caddy web user" \
@@ -137,14 +139,29 @@ go test -v
 
 %post
 %{_sbindir}/setcap cap_net_bind_service=+ep %{_bindir}/caddy
+if test -f /.dockerenv; then exit 0; fi
+%systemd_post %{name}.service
+%systemd_post %{name}-api.service
+
+
+%preun
+if test -f /.dockerenv; then exit 0; fi
+%systemd_preun %{name}.service
+%systemd_preun %{name}-api.service
+
+
+%postun
+if test -f /.dockerenv; then exit 0; fi
+%systemd_postun %{name}.service
+%systemd_postun %{name}-api.service
 
 
 %files
 %doc AUTHORS README.md
 %license LICENSE
 %{_bindir}/caddy
-%{_unitdir}/caddy.service
-%{_unitdir}/caddy-api.service
+%{_unitdir}/%{name}.service
+%{_unitdir}/%{name}-api.service
 %{_usr}/lib/tmpfiles.d/caddy.conf
 %defattr(-, root, %{caddy_group}, -)
 %config(noreplace) %{caddy_config}/Caddyfile

--- a/SPECS/el9/caddy.spec
+++ b/SPECS/el9/caddy.spec
@@ -13,7 +13,7 @@ Summary:        Fast and extensible multi-platform HTTP/1-2-3 web server with au
 License:        ASL 2.0 and MIT and BSD
 URL:            https://github.com/caddyserver/caddy
 Source0:        https://github.com/caddyserver/caddy/archive/v%{version}/caddy-%{version}.tar.gz
-Source1:        caddy-no-binary-mods.patch
+Patch0:         caddy-no-binary-mods.patch
 
 BuildRequires:  git
 BuildRequires:  systemd-rpm-macros
@@ -24,12 +24,12 @@ Caddy is a powerful, extensible platform to serve your sites, services, and apps
 
 
 %prep
-%autosetup
+%autosetup -N
 cd "${HOME}"
 %{__rm} -fr %{_builddir}/caddy-%{version}
 %{__git} clone --single-branch -b v%{version} %{url} %{_builddir}/caddy-%{version}
 cd %{_builddir}/caddy-%{version}
-%{__patch} -p1 < %{SOURCE1}
+%autopatch -p1
 
 
 %build

--- a/SPECS/el9/caddy.spec
+++ b/SPECS/el9/caddy.spec
@@ -1,0 +1,159 @@
+%global caddy_config %{_sysconfdir}/caddy
+%global caddy_home %{_sharedstatedir}/caddy
+%global caddy_user caddy
+%global caddy_group %{caddy_user}
+%global caddy_uid 517
+%global caddy_gid %{caddy_uid}
+
+Name:           caddy
+Version:        %{rpmbuild_version}
+Release:        %{rpmbuild_release}%{?dist}
+Summary:        Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
+License:        ASL 2.0
+URL:            https://github.com/caddyserver/caddy
+Source0:        https://github.com/caddyserver/caddy/archive/v%{version}/caddy-%{version}.tar.gz
+
+BuildRequires:  git
+
+%description
+Caddy is a powerful, extensible platform to serve your sites, services, and apps, written in Go.
+
+
+%prep
+%autosetup -n caddy-%{version}
+cd "${HOME}"
+%{__rm} -fr %{_builddir}/caddy-%{version}
+%{__git} clone --single-branch -b v%{version} %{url} %{_builddir}/caddy-%{version}
+cd %{_builddir}/caddy-%{version}
+
+
+%build
+%{__mkdir_p} caddy@%{version}
+%{__install} cmd/caddy/main.go caddy@%{version}
+pushd caddy@%{version}
+go mod init caddy
+go get -v
+go build -v
+popd
+
+
+%install
+%{__install} -d -m 0755 \
+ %{buildroot}%{_bindir} \
+ %{buildroot}%{_sysconfdir}/sysconfig \
+ %{buildroot}%{_unitdir} \
+ %{buildroot}%{_usr}/lib/tmpfiles.d
+%{__install} -d -m 0750 \
+ %{buildroot}%{caddy_home} \
+ %{buildroot}%{_rundir}/caddy \
+ %{buildroot}%{caddy_config}
+%{__install} -p caddy@%{version}/caddy %{buildroot}%{_bindir}
+echo "d %{_rundir}/%{name} 0750 %{caddy_user} %{caddy_group} -" > \
+     %{buildroot}%{_usr}/lib/tmpfiles.d/caddy.conf
+
+# Configuration files.
+touch %{buildroot}%{_sysconfdir}/sysconfig/caddy \
+      %{buildroot}%{caddy_config}/Caddyfile
+chmod 0750 %{buildroot}%{_sysconfdir}/sysconfig/caddy
+
+# Unit files.
+cat <<EOF > %{buildroot}%{_unitdir}/caddy.service
+[Unit]
+Description=Caddy
+Documentation=https://caddyserver.com/docs/
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Type=notify
+User=%{caddy_user}
+Group=%{caddy_group}
+EnvironmentFile=%{_sysconfdir}/sysconfig/caddy
+ExecStart=%{_bindir}/caddy run --environ --config %{caddy_config}/Caddyfile
+ExecReload=%{_bindir}/caddy reload --config %{caddy_config}/Caddyfile --force
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+LimitNPROC=512
+PrivateTmp=true
+ProtectSystem=full
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF > %{buildroot}%{_unitdir}/caddy-api.service
+[Unit]
+Description=Caddy
+Documentation=https://caddyserver.com/docs/
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Type=notify
+User=%{caddy_user}
+Group=%{caddy_group}
+EnvironmentFile=%{_sysconfdir}/sysconfig/caddy
+ExecStart=%{_bindir}/caddy run --environ --resume
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+LimitNPROC=512
+PrivateTmp=true
+ProtectSystem=full
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+
+%check
+go get -v
+pushd cmd/caddy
+go build -v
+popd
+go test -v
+
+
+%pre
+%{_bindir}/getent group %{caddy_group} >/dev/null || \
+    groupadd \
+        --force \
+        --gid %{caddy_gid} \
+        --system \
+        %{caddy_group}
+
+%{_bindir}/getent passwd %{caddy_user} >/dev/null || \
+    useradd \
+        --uid %{caddy_uid} \
+        --gid %{caddy_group} \
+        --comment "Caddy web user" \
+        --shell %{_sbindir}/nologin \
+        --home-dir %{caddy_home} \
+        --no-create-home \
+        --system \
+        %{caddy_user}
+
+
+%post
+%{_sbindir}/setcap cap_net_bind_service=+ep %{_bindir}/caddy
+
+
+%files
+%doc AUTHORS README.md
+%license LICENSE
+%{_bindir}/caddy
+%{_unitdir}/caddy.service
+%{_unitdir}/caddy-api.service
+%{_usr}/lib/tmpfiles.d/caddy.conf
+%defattr(-, root, %{caddy_group}, -)
+%config(noreplace) %{caddy_config}/Caddyfile
+%config(noreplace) %{_sysconfdir}/sysconfig/caddy
+%defattr(-, %{caddy_user}, %{caddy_group}, -)
+%dir %{_rundir}/caddy
+%dir %{caddy_home}
+
+
+%changelog
+* %(%{_bindir}/date "+%%a %%b %%d %%Y") %{rpmbuild_name} <%{rpmbuild_email}> - %{version}-%{rpmbuild_release}
+- %{version}-%{rpmbuild_release}

--- a/SPECS/el9/caddy.spec
+++ b/SPECS/el9/caddy.spec
@@ -31,6 +31,8 @@ cd %{_builddir}/caddy-%{version}
 
 
 %build
+export CGO_CFLAGS="%{optflags}"
+export CGO_LDFLAGS="%{?build_ldflags}"
 %{__mkdir_p} caddy@%{version}
 %{__install} cmd/caddy/main.go caddy@%{version}
 pushd caddy@%{version}
@@ -116,6 +118,8 @@ EOF
 
 
 %check
+export CGO_CFLAGS="%{optflags}"
+export CGO_LDFLAGS="%{?build_ldflags}"
 go get -v
 pushd cmd/caddy
 go build -v

--- a/SPECS/el9/step-ca.spec
+++ b/SPECS/el9/step-ca.spec
@@ -117,6 +117,7 @@ EOF
 
 
 %post
+%{_sbindir}/setcap cap_net_bind_service=+ep %{_bindir}/step-ca
 if test -f /.dockerenv; then exit 0; fi
 %systemd_post %{name}.service
 

--- a/SPECS/el9/step-ca.spec
+++ b/SPECS/el9/step-ca.spec
@@ -14,6 +14,7 @@ Source0:        https://github.com/smallstep/certificates/archive/v%{version}/ce
 
 BuildRequires:  git
 BuildRequires:  openssl-devel
+BuildRequires:  systemd-rpm-macros
 
 
 %description
@@ -55,7 +56,7 @@ STEPPATH=%{_sharedstatedir}/step-ca
 EOF
 
 # Unit file.
-cat <<EOF > %{buildroot}%{_unitdir}/step-ca.service
+cat <<EOF > %{buildroot}%{_unitdir}/%{name}.service
 [Unit]
 Description=step-ca
 After=basic.target network.target
@@ -96,23 +97,38 @@ EOF
 
 
 %pre
-getent group %{step_ca_group} >/dev/null || \
-    groupadd \
+%{_bindir}/getent group %{step_ca_group} >/dev/null || \
+    %{_sbindir}/groupadd \
         --force \
         --gid %{step_ca_gid} \
         --system \
         %{step_ca_group}
 
-getent passwd %{step_ca_user} >/dev/null || \
-    useradd \
+%{_bindir}/getent passwd %{step_ca_user} >/dev/null || \
+    %{_sbindir}/useradd \
         --uid %{step_ca_uid} \
         --gid %{step_ca_group} \
         --comment "Smallstep CA User" \
-        --shell /sbin/nologin \
+        --shell %{_sbindir}/nologin \
         --home-dir %{step_ca_home} \
         --no-create-home \
         --system \
         %{step_ca_user}
+
+
+%post
+if test -f /.dockerenv; then exit 0; fi
+%systemd_post %{name}.service
+
+
+%preun
+if test -f /.dockerenv; then exit 0; fi
+%systemd_preun %{name}.service
+
+
+%postun
+if test -f /.dockerenv; then exit 0; fi
+%systemd_postun %{name}.service
 
 
 %check
@@ -124,7 +140,7 @@ export CI=true
 %doc CHANGELOG.md README.md
 %license LICENSE
 %{_bindir}/step-ca
-%{_unitdir}/step-ca.service
+%{_unitdir}/%{name}.service
 %{_usr}/lib/tmpfiles.d/step-ca.conf
 %config(noreplace) %{_sysconfdir}/sysconfig/step-ca
 %defattr(-, %{step_ca_user}, %{step_ca_group}, -)

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -48,6 +48,9 @@ x-rpmbuild:
     SFCGAL:
       image: rpmbuild-sfcgal
       version: &SFCGAL_version 1.3.10-1
+    caddy:
+      image: rpmbuild-caddy
+      version: &caddy_version 2.6.4-1
     dumb-init:
       image: rpmbuild-generic
       version: 1.2.5-1
@@ -286,6 +289,14 @@ services:
       dockerfile: docker/el7/Dockerfile.rpmbuild-pgdg
     image: ${IMAGE_PREFIX}rpmbuild-pgdg
   # RPM images
+  rpmbuild-caddy:
+    <<: *service_defaults
+    build:
+      <<: *build_defaults
+      args:
+        <<: *build_args_defaults
+        rpmbuild_image: rpmbuild-generic
+      dockerfile: docker/el7/Dockerfile.rpmbuild-go
   rpmbuild-cgal:
     <<: *service_defaults
     build:

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -229,10 +229,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.24.0-1
+      version: &step_ca_version 0.24.1-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.24.1-1
+      version: &step_cli_version 0.24.3-1
     tbb:
       image: rpmbuild-tbb
       version: &tbb_version 2020.3-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -185,10 +185,10 @@ x-rpmbuild:
       version: &sqlite_pcre_version 2007.1.20-1
     step-ca:
       image: rpmbuild-smallstep
-      version: &step_ca_version 0.24.0-1
+      version: &step_ca_version 0.24.1-1
     step-cli:
       image: rpmbuild-smallstep
-      version: &step_cli_version 0.24.1-1
+      version: &step_cli_version 0.24.3-1
     wal-g:
       image: rpmbuild-wal-g
       version: &walg_version 2.0.1-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -55,6 +55,9 @@ x-rpmbuild:
     armadillo:
       image: rpmbuild-armadillo
       version: &armadillo_version 12.2.0-1
+    caddy:
+      image: rpmbuild-caddy
+      version: &caddy_version 2.6.4-1
     gdal:
       image: rpmbuild-gdal
       version: &gdal_version 3.6.3-1
@@ -238,6 +241,14 @@ services:
       args:
         <<: *build_args_defaults
         packages: ${RPMBUILD_ARMADILLO_PACKAGES}
+  rpmbuild-caddy:
+    <<: *service_defaults
+    build:
+      <<: *build_defaults
+      args:
+        <<: *build_args_defaults
+        rpmbuild_image: rpmbuild-generic
+      dockerfile: docker/el9/Dockerfile.rpmbuild-go
   rpmbuild-cgal:
     <<: *service_defaults
     build:

--- a/docker/el9/Dockerfile.rpmbuild
+++ b/docker/el9/Dockerfile.rpmbuild
@@ -36,8 +36,10 @@ RUN --mount=type=cache,target=/var/cache/dnf \
         --setopt=keepcache=1 \
         --setopt=baseos.repo_gpgcheck=1 \
         --setopt=appstream.repo_gpgcheck=1 \
-        --setopt=crb.enabled=1 \
-        --setopt=crb.repo_gpgcheck=1 && \
+        --setopt=crb.repo_gpgcheck=1 \
+        --setopt=extras-common.repo_gpgcheck=1 \
+        --setopt=crb.enabled=1  \
+    && \
     dnf -q -y update && \
     dnf --setopt=tsflags='' reinstall -y tzdata && \
     dnf -q -y install \


### PR DESCRIPTION
Adds the [Caddy webserver](https://caddyserver.com) to our RPMs.  It's a webserver written in a memory safe language (Go), may be configured dynamically via API, and doesn't require `root` privileges like Apache or Nginx.

### Other Changes

* Upgrade Smallstep CA to [0.24.1](https://github.com/smallstep/certificates/releases/tag/v0.24.1) and CLI to [0.24.3](https://github.com/smallstep/cli/releases/tag/v0.24.3).  Add SystemD macros for `step-ca` package and automatically add network binding capabilities in RPM post-install hook.
* Verify `extras` repository metadata on EL9.