### PR TITLE
Upgrade PostGIS to 3.2.5 on EL7

### DIFF
--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -142,7 +142,7 @@ x-rpmbuild:
       version: &passenger_version 6.0.17-1
     postgis:
       image: rpmbuild-postgis
-      version: &postgis_version 3.2.4-1
+      version: &postgis_version 3.2.5-1
       defines:
         gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version


### PR DESCRIPTION
We'll wait for GDAL 3.7.0 release on EL9 before upgrading to 3.3.3.