### PR TITLE
GDAL 3.7.0

### DIFF
--- a/SOURCES/el9/gdal-proj-9.2.1.patch
+++ b/SOURCES/el9/gdal-proj-9.2.1.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] autotest/osr: make it work with latest PROJ master
  autotest/osr/osr_proj4.py | 5 +++++
  2 files changed, 10 insertions(+)
 
-diff --git a/gdalautotest-3.6.4/osr/osr_compd.py b/gdalautotest-3.6.4/osr/osr_compd.py
+diff --git a/gdalautotest-3.7.0/osr/osr_compd.py b/gdalautotest-3.7.0/osr/osr_compd.py
 index 4a55a946d03..15144941b60 100755
---- a/gdalautotest-3.6.4/osr/osr_compd.py
-+++ b/gdalautotest-3.6.4/osr/osr_compd.py
+--- a/gdalautotest-3.7.0/osr/osr_compd.py
++++ b/gdalautotest-3.7.0/osr/osr_compd.py
 @@ -267,6 +267,11 @@ def test_osr_compd_6():
          "Unknown based on GRS80 ellipsoid using towgs84=0,0,0,0,0,0,0",
          "Unknown_based_on_GRS80_ellipsoid",
@@ -24,11 +24,11 @@ index 4a55a946d03..15144941b60 100755
      wkt = wkt.replace(
          "unknown using geoidgrids=g2003conus.gtx,g2003alaska.gtx,g2003h01.gtx,g2003p01.gtx",
          "unknown",
-diff --git a/gdalautotest-3.6.4/osr/osr_proj4.py b/gdalautotest-3.6.4/osr/osr_proj4.py
+diff --git a/gdalautotest-3.7.0/osr/osr_proj4.py b/gdalautotest-3.7.0/osr/osr_proj4.py
 index f5d14e65290..5c511a9fb1e 100755
---- a/gdalautotest-3.6.4/osr/osr_proj4.py
-+++ b/gdalautotest-3.6.4/osr/osr_proj4.py
-@@ -242,6 +242,11 @@ def test_osr_proj4_10():
+--- a/gdalautotest-3.7.0/osr/osr_proj4.py
++++ b/gdalautotest-3.7.0/osr/osr_proj4.py
+@@ -229,6 +229,11 @@ def test_osr_proj4_10():
          "Unknown based on WGS84 ellipsoid using towgs84=0,0,0,0,0,0,0",
          "Unknown_based_on_WGS84_ellipsoid",
      )

--- a/SPECS/el9/gdal.spec
+++ b/SPECS/el9/gdal.spec
@@ -307,11 +307,15 @@ addopts =
     --deselect gcore/vsizip.py::test_vsizip_create_zip64_stream_larger_than_4G
     --deselect gdrivers/vrtwarp.py::test_vrtwarp_read_blocks_larger_than_2_gigapixels
     --deselect gdrivers/wms.py::test_wms_16
+    --deselect ogr/ogr_fgdb.py::test_ogr_fgdb_19
+    --deselect ogr/ogr_fgdb.py::test_ogr_fgdb_19bis
+    --deselect ogr/ogr_fgdb.py::test_ogr_fgdb_20
     --deselect ogr/ogr_fgdb.py::test_ogr_fgdb_21
     --deselect ogr/ogr_pg.py::test_ogr_pg_70
     --deselect ogr/ogr_pg.py::test_ogr_pg_skip_views
     --deselect ogr/ogr_wfs.py::test_ogr_wfs_esri_2
     --deselect ogr/ogr_wfs.py::test_ogr_wfs_erdas_apollo
+    --deselect ogr/ogr_wfs.py::test_ogr_wfs_tinyows
     --deselect pyscripts/test_gdal2tiles.py::test_gdal2tiles_py_invalid_srs
     --deselect pyscripts/test_gdal2tiles.py::test_gdal2tiles_py_resampling_option
     --deselect pyscripts/test_gdal2tiles.py::test_gdal2tiles_py_simple

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -60,10 +60,10 @@ x-rpmbuild:
       version: &caddy_version 2.6.4-1
     gdal:
       image: rpmbuild-gdal
-      version: &gdal_version 3.6.4-1
+      version: &gdal_version 3.7.0-1
       defines:
         geos_min_version: *geos_min_version
-        proj_min_version: *proj_min_version
+        proj_min_version: 9.2.0
     geos:
       image: rpmbuild-generic
       version: &geos_version 3.11.2-1


### PR DESCRIPTION
* Upgrade GDAL to 3.7.0; based off @hummeltech's `GDALv3.7.0` branch work.
* Requires additional releases after merge so that programs link to `libgdal.so.33` instead:
  * PostGIS 3.3.3
  * Mapnik 3.1.0-2
  * MapServer 8.0.1-2 / 7.6.4-2