### PR TITLE
GDAL 3.7 Upgrade

### DIFF
--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -27,15 +27,15 @@ x-rpmbuild:
     rpmbuild_image: rpmbuild
   # Use consistent values for minimum versions for RPM build
   # and runtime requirements.
-  minimum_versions:
-    gdal: &gdal_min_version 3.6.0
-    geos: &geos_min_version 3.11.0
-    libosmium: &libosmium_min_version 2.18.0
+  version_limits:
+    gdal_min_version: &gdal_min_version 3.7.0
+    geos_min_version: &geos_min_version 3.11.0
+    libosmium_min_version: &libosmium_min_version 2.18.0
     postgis_min_version: &postgis_min_version 3.3.0
-    proj: &proj_min_version 9.1.0
-    protobuf-c: &protobuf_c_min_version 1.3.0
-    protobuf: &protobuf_min_version 3.0.0
-    protozero: &protozero_min_version 1.7.0
+    proj_min_version: &proj_min_version 9.2.0
+    protobuf-c_min_version: &protobuf_c_min_version 1.3.0
+    protobuf_min_version: &protobuf_min_version 3.0.0
+    protozero_min_version: &protozero_min_version 1.7.0
     sqlite_min_version: &sqlite_min_version 3.11.0
   # Configuration for building every dependency RPM.
   rpms:
@@ -63,7 +63,7 @@ x-rpmbuild:
       version: &gdal_version 3.7.0-1
       defines:
         geos_min_version: *geos_min_version
-        proj_min_version: 9.2.0
+        proj_min_version: *proj_min_version
     geos:
       image: rpmbuild-generic
       version: &geos_version 3.11.2-1
@@ -91,7 +91,7 @@ x-rpmbuild:
       version: &libpqxx_version 7.7.5-1
     mapnik:
       image: rpmbuild-mapnik
-      version: &mapnik_version 3.1.0-1
+      version: &mapnik_version 3.1.0-2
       defines:
         gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version
@@ -99,7 +99,7 @@ x-rpmbuild:
         proj_min_version: *proj_min_version
     mapserver:
       image: rpmbuild-mapserver
-      version: &mapserver_version 8.0.1-1
+      version: &mapserver_version 8.0.1-2
       defines:
         gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version
@@ -145,7 +145,7 @@ x-rpmbuild:
       version: &passenger_version 6.0.17-1
     postgis:
       image: rpmbuild-postgis
-      version: &postgis_version 3.3.2-1
+      version: &postgis_version 3.3.3-1
       defines:
         gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version

--- a/docker/el9/Dockerfile.rpmbuild-geoint-deps
+++ b/docker/el9/Dockerfile.rpmbuild-geoint-deps
@@ -4,6 +4,8 @@ ARG rpmbuild_image_prefix
 # hadolint ignore=DL3007
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
 
+ARG geoint_deps_channel=stable
+ARG geoint_deps_gpgcheck=1
 ARG gem_packages
 ARG packages
 ARG python_packages
@@ -12,6 +14,8 @@ ARG python_packages
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 # hadolint ignore=DL3013,DL3028,DL3040,DL3041
 RUN --mount=type=cache,target=/var/cache/dnf \
+    GEOINT_DEPS_CHANNEL=${geoint_deps_channel} \
+    GEOINT_DEPS_GPGCHECK=${geoint_deps_gpgcheck} \
     /usr/local/bin/geoint-deps-repo.sh && \
     if [ -n "${packages:-}" ] ; then dnf -q -y install ${packages}; fi && \
     if [ -n "${gem_packages:-}" ] ; then gem install ${gem_packages}; fi && \

--- a/docker/el9/Dockerfile.rpmbuild-geoint-pgdg
+++ b/docker/el9/Dockerfile.rpmbuild-geoint-pgdg
@@ -4,6 +4,8 @@ ARG rpmbuild_image_prefix
 # hadolint ignore=DL3007
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
 
+ARG geoint_deps_channel=stable
+ARG geoint_deps_gpgcheck=1
 ARG gem_packages
 ARG packages
 ARG python_packages
@@ -15,6 +17,8 @@ USER root
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 # hadolint ignore=DL3013,DL3028,DL3040,DL3041
 RUN --mount=type=cache,target=/var/cache/dnf \
+    GEOINT_DEPS_CHANNEL=${geoint_deps_channel} \
+    GEOINT_DEPS_GPGCHECK=${geoint_deps_gpgcheck} \
     /usr/local/bin/geoint-deps-repo.sh && \
     if [ -n "${packages}" ] ; then dnf -q -y install ${packages}; fi && \
     if [ -n "${gem_packages:-}" ] ; then gem install ${gem_packages}; fi && \

--- a/scripts/geoint-deps-repo.sh
+++ b/scripts/geoint-deps-repo.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 source /etc/os-release
 GEOINT_DEPS_CHANNEL="${GEOINT_DEPS_CHANNEL:-stable}"
 GEOINT_DEPS_BASEURL="${GEOINT_DEPS_BASEURL:-https://geoint-deps.s3.amazonaws.com/el${VERSION_ID}/${GEOINT_DEPS_CHANNEL}}"
+GEOINT_DEPS_GPGCHECK="${GEOINT_DEPS_GPGCHECK:-1}"
 GEOINT_DEPS_KEY="${GEOINT_DEPS_KEY:-/etc/pki/rpm-gpg/RPM-GPG-KEY-GEOINT}"
 GEOINT_DEPS_REPO="${GEOINT_DEPS_REPO:-/etc/yum.repos.d/geoint-deps.repo}"
 
@@ -40,11 +41,11 @@ BKvRcPtz0vU2ZA+JjgCXqpu0sLpMY/CGlgn9m4XlZYQ8ok/fe1no7k6cJat1EHLH
 EOF
 
 cat > "${GEOINT_DEPS_REPO}" <<EOF
-[geoint-deps-${GEOINT_DEPS_CHANNEL}]
+[geoint-deps-${GEOINT_DEPS_CHANNEL/\//-}]
 name = GEOINT Dependencies
 baseurl = ${GEOINT_DEPS_BASEURL}
 enable = 1
-gpgcheck = 1
+gpgcheck = ${GEOINT_DEPS_GPGCHECK}
 gpgkey=file://${GEOINT_DEPS_KEY}
-repo_gpgcheck = 1
+repo_gpgcheck = ${GEOINT_DEPS_GPGCHECK}
 EOF


### PR DESCRIPTION
Companion to #146, GDAL's ABI has changed (`libgdal.so` has been updated to version 33 from 32 in 3.6.0), so everything linking to it needs to be upgraded or a new release:
* Upgrade PostGIS to 3.3.3.
* Create new Mapnik and MapServer releases, 3.1.0-2 and 8.0.1-2, respectively.
* Allow customizing GEOINT dependency channel/signing status via container build arguments.  Used this to test GDAL from #146, e.g.:
    ```diff
    diff --git a/docker-compose.el9.yml b/docker-compose.el9.yml
    index b70076d..2e2fd11 100644
    --- a/docker-compose.el9.yml
    +++ b/docker-compose.el9.yml
    @@ -329,6 +329,8 @@ services:
           <<: *build_defaults
           args:
             <<: *build_args_defaults
    +        geoint_deps_channel: non-stable/gdal-3.7.0
    +        geoint_deps_gpgcheck: "0"
             packages: ${RPMBUILD_MAPNIK_PACKAGES}
             rpmbuild_image: rpmbuild-pgdg
           dockerfile: docker/el9/Dockerfile.rpmbuild-geoint-pgdg
    @@ -338,6 +340,8 @@ services:
           <<: *build_defaults
           args:
             <<: *build_args_defaults
    +        geoint_deps_channel: non-stable/gdal-3.7.0
    +        geoint_deps_gpgcheck: "0"
             packages: ${RPMBUILD_MAPSERVER_PACKAGES}
           dockerfile: docker/el9/Dockerfile.rpmbuild-geoint-deps
       rpmbuild-openstreetmap-carto:
    @@ -394,6 +398,8 @@ services:
           <<: *build_defaults
           args:
             <<: *build_args_defaults
    +        geoint_deps_channel: non-stable/gdal-3.7.0
    +        geoint_deps_gpgcheck: "0"
             packages: ${RPMBUILD_POSTGIS_PACKAGES}
             rpmbuild_image: rpmbuild-pgdg
           dockerfile: docker/el9/Dockerfile.rpmbuild-geoint-pgdg
    ```