### PR TITLE
Update `spawn-fcgi`'s source to point to `GitHub`

### DIFF
--- a/SPECS/el9/spawn-fcgi.spec
+++ b/SPECS/el9/spawn-fcgi.spec
@@ -5,7 +5,7 @@ Release:        %{rpmbuild_release}%{?dist}
 
 License:        BSD
 URL:            https://redmine.lighttpd.net/projects/spawn-fcgi/
-Source0:        http://download.lighttpd.net/spawn-fcgi/releases-1.6.x/spawn-fcgi-%{version}.tar.gz
+Source0:        https://github.com/lighttpd/spawn-fcgi/archive/refs/tags/spawn-fcgi-%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  make
@@ -16,10 +16,11 @@ processes, which can be local or remote.
 
 
 %prep
-%autosetup
+%autosetup -n spawn-fcgi-spawn-fcgi-%{version}
 
 
 %build
+./autogen.sh
 %configure
 %make_build
 

--- a/docs/provenance.el9.md
+++ b/docs/provenance.el9.md
@@ -261,7 +261,7 @@ is released under the [LGPLv2 license](https://gitlab.com/Oslandia/SFCGAL/-/blob
 
 ## spawn-fcgi
 
-The [spawn-fcgi](https://redmine.lighttpd.net/projects/spawn-fcgi/) source archives are obtained directly from the [Lighttpd website](http://download.lighttpd.net/spawn-fcgi) and are BSD licensed.
+The [spawn-fcgi](https://redmine.lighttpd.net/projects/spawn-fcgi/) source archives are obtained directly from [GitHub](https://github.com/lighttpd/spawn-fcgi) and are BSD licensed.
 
 The [`spawn-fcgi.spec`](../SPECS/el9/spawn-fcgi.spec) file originates from [Fedora's `spawn-fcgi` RPM](https://src.fedoraproject.org/rpms/spawn-fcgi) and is released under the [Fedora license](./licenses/Fedora-LICENSE).
 


### PR DESCRIPTION
`lighttpd.net` appears to be having some issues, I.E.:
* http://www.lighttpd.net/
* https://redmine.lighttpd.net/projects/spawn-fcgi
* http://download.lighttpd.net/spawn-fcgi/releases-1.6.x/spawn-fcgi-1.6.5.tar.gz