### PR TITLE
osm2pgsql 1.8.1-2 [EL7]

### DIFF
--- a/SOURCES/el7/osm2pgsql-replication.patch
+++ b/SOURCES/el7/osm2pgsql-replication.patch
@@ -1,8 +1,8 @@
 diff --git a/scripts/osm2pgsql-replication b/scripts/osm2pgsql-replication
-index 207d7ccd..0ee335a2 100755
+index 207d7ccd..3f5ee0d9 100755
 --- a/scripts/osm2pgsql-replication
 +++ b/scripts/osm2pgsql-replication
-@@ -95,7 +95,7 @@ def table_exists(conn, table_name, schema_name=None):
+@@ -95,14 +95,14 @@ def table_exists(conn, table_name, schema_name=None):
          return cur.rowcount > 0
  
  
@@ -11,6 +11,14 @@ index 207d7ccd..0ee335a2 100755
      """ Determine the date of the database from the newest object in the
          database.
      """
+     # First, find the way with the highest ID in the database
+     # Using nodes would be more reliable but those are not cached by osm2pgsql.
+     with conn.cursor() as cur:
+-        table = sql.Identifier(schema, f'{prefix}_ways')
++        table = sql.Identifier(f'{prefix}_ways')
+         cur.execute(sql.SQL("SELECT max(id) FROM {}").format(table))
+         osmid = cur.fetchone()[0] if cur.rowcount == 1 else None
+ 
 @@ -112,7 +112,7 @@ def compute_database_date(conn, schema, prefix):
  
      LOG.debug("Using way id %d for timestamp lookup", osmid)
@@ -39,3 +47,12 @@ index 207d7ccd..0ee335a2 100755
      srcgrp = grp.add_mutually_exclusive_group()
      srcgrp.add_argument('--osm-file', metavar='FILE',
                          help='Get replication information from the given file.')
+@@ -539,7 +542,7 @@ def main():
+                         level=max(4 - args.verbose, 1) * 10)
+ 
+     args.table_name = f'{args.prefix}_replication_status'
+-    args.table = sql.Identifier(args.middle_schema, args.table_name)
++    args.table = sql.Identifier(args.table_name)
+ 
+     conn = connect(args)
+ 

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -131,7 +131,7 @@ x-rpmbuild:
         protozero_min_version: *protozero_min_version
     osm2pgsql:
       image: rpmbuild-osm2pgsql
-      version: &osm2pgsql_version 1.8.1-1
+      version: &osm2pgsql_version 1.8.1-2
       defines:
         libosmium_min_version: *libosmium_min_version
         proj_min_version: *proj_min_version


### PR DESCRIPTION
The `osm2pgsql-replication` patch needs to be updated to use `sql.Identifier` in a supported way with EL7's `python3-psycopg2`.