### PR TITLE
openstreetmap-carto 5.4.0-4 [EL7]

### DIFF
--- a/SPECS/el7/openstreetmap-carto.spec
+++ b/SPECS/el7/openstreetmap-carto.spec
@@ -42,6 +42,7 @@ Requires:       google-noto-cjk-fonts
 Requires:       google-noto-emoji-color-fonts
 Requires:       google-noto-emoji-fonts
 Requires:       google-noto-fonts-common
+Requires:       google-noto-fonts-extra
 Requires:       google-noto-kufi-arabic-fonts
 Requires:       google-noto-naskh-arabic-fonts
 Requires:       google-noto-naskh-arabic-ui-fonts
@@ -154,6 +155,9 @@ Requires:       google-noto-serif-georgian-fonts
 Requires:       google-noto-serif-khmer-fonts
 Requires:       google-noto-serif-lao-fonts
 Requires:       google-noto-serif-thai-fonts
+Requires:       hanazono-fonts
+Requires:       %{name}-data-fossgis = %{version}-%{release}
+Requires:       %{name}-data-natural-earth = %{version}-%{release}
 Requires:       python3-psycopg2
 Requires:       python36-PyYAML
 Requires:       python36-requests

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -106,7 +106,7 @@ x-rpmbuild:
       version: &ogdi_version 4.1.0-1
     openstreetmap-carto:
       image: rpmbuild-openstreetmap-carto
-      version: &openstreetmap_carto_version 5.4.0-3
+      version: &openstreetmap_carto_version 5.4.0-4
       arch: noarch
       defines:
         data_natural_earth_version: 5.1.0


### PR DESCRIPTION
Add additional font and data requirements, like we conveniently have on EL9 when installing `openstreetmap-carto`.