### PR TITLE
Upgrade Armadillo from v12.6.0 to v12.6.2 (EL9)

### DIFF
--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -54,7 +54,7 @@ x-rpmbuild:
         _smp_ncpus_max: 4
     armadillo:
       image: rpmbuild-armadillo
-      version: &armadillo_version 12.6.0-1
+      version: &armadillo_version 12.6.2-1
     caddy:
       image: rpmbuild-caddy
       version: &caddy_version 2.6.4-1


### PR DESCRIPTION
https://sourceforge.net/projects/arma/files/

v12.6.0 has been removed from the download page.