### PR TITLE
Also use support-files for hanazono-fonts (EL7)

### DIFF
--- a/SPECS/el7/hanazono-fonts.spec
+++ b/SPECS/el7/hanazono-fonts.spec
@@ -10,7 +10,7 @@ Summary: Japanese Mincho-typeface TrueType font
 
 License: Hanazono Font License & OFL 1.1
 URL:     http://fonts.jp/hanazono/
-Source0: https://osdn.net/projects/hanazono-font/downloads/68253/%{archivename}.zip
+Source0: https://geoint-deps.s3.amazonaws.com/support-files/%{archivename}.zip
 Source1: %{name}-fontconfig.conf
 
 BuildArch: noarch


### PR DESCRIPTION
The EL7 build pipeline will otherwise fail, this applies the same change from https://github.com/radiant-maxar/geoint-deps/pull/157