### PR TITLE
GEOS 3.12.0 / GDAL 3.7.1-2 / PostGIS 3.4.0

### DIFF
--- a/SOURCES/el9/postgis-3.4-gdalfpic.patch
+++ b/SOURCES/el9/postgis-3.4-gdalfpic.patch
@@ -1,13 +1,13 @@
 diff --git a/configure b/configure
-index a4908dc..c870df7 100755
+index 0e94580..e406a2e 100755
 --- a/configure
 +++ b/configure
-@@ -18511,7 +18511,7 @@ $as_echo "$OGR_ENABLED" >&6; }
+@@ -20531,7 +20531,7 @@ $as_echo "$OGR_ENABLED" >&6; }
  				LIBGDAL_CFLAGS=`$GDAL_CONFIG --cflags`
  
  		CPPFLAGS_SAVE="$CPPFLAGS"
 -		CPPFLAGS="$LIBGDAL_CFLAGS"
 +		CPPFLAGS="$LIBGDAL_CFLAGS -fPIC"
  		CFLAGS_SAVE="$CFLAGS"
- 		CFLAGS=`"$PG_CONFIG" --cflags`
  		CC_SAVE="$CC"
+ 

--- a/SPECS/el9/postgis.spec
+++ b/SPECS/el9/postgis.spec
@@ -12,20 +12,9 @@
 %global postgis_micro %(echo %{rpmbuild_version} | awk -F. '{ print $3 }')
 %global postgis_majorversion %{postgis_major}.%{postgis_minor}
 %global postgiscurrmajorversion %(echo %{postgis_majorversion}|tr -d '.')
-
-%{!?postgis_prev_version: %global postgis_prev_version 2.5.8}
-%global postgis_prev_major %(echo %{postgis_prev_version} | awk -F. '{ print $1 }')
-%global postgis_prev_minor %(echo %{postgis_prev_version} | awk -F. '{ print $2 }')
-%global postgis_prev_micro %(echo %{postgis_prev_version} | awk -F. '{ print $3 }')
-%global postgis_prev_majorversion %{postgis_prev_major}.%{postgis_prev_minor}
-%global postgis_prev_dotless %(echo %{postgis_prev_majorversion}|tr -d '.')
-
 %global sname postgis
-%if 0%{postgis_major} >= 3
 %global postgisliblabel %{postgis_major}
-%else
-%global postgisliblabel %{postgis_majorversion}
-%endif
+
 
 Summary:	Geographic Information Systems Extensions to PostgreSQL
 Name:           postgis
@@ -33,10 +22,9 @@ Version:        %{rpmbuild_version}
 Release:        %{rpmbuild_release}%{?dist}
 License:        GPLv2+
 Source0:        https://download.osgeo.org/%{name}/source/%{name}-%{version}%{?prerelease}.tar.gz
-Source2:        https://download.osgeo.org/%{name}/docs/%{name}-%{version}%{?prerelease}.pdf
-Source3:        https://download.osgeo.org/%{name}/source/%{name}-%{postgis_prev_version}.tar.gz
-Source4:        postgis-filter-requires-perl-Pg.sh
-Patch0:         postgis-3.1-gdalfpic.patch
+Source1:        https://download.osgeo.org/%{name}/docs/%{name}-%{version}%{?prerelease}-en.pdf
+Source2:        postgis-filter-requires-perl-Pg.sh
+Patch0:         postgis-3.4-gdalfpic.patch
 
 URL:		http://www.postgis.net/
 
@@ -60,8 +48,6 @@ Requires:       postgresql%{postgres_version}
 Requires:       postgresql%{postgres_version}-contrib
 Requires(post):	%{_sbindir}/update-alternatives
 
-Provides:       %{name}%{postgis_prev_dotless}_%{postgres_version} = %{version}-%{release}
-
 %description
 PostGIS adds support for geographic objects to the PostgreSQL object-relational
 database. In effect, PostGIS "spatially enables" the PostgreSQL server,
@@ -73,7 +59,6 @@ certified as compliant with the "Types and Functions" profile.
 %package devel
 Summary:        Development headers and libraries for PostGIS
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Provides:       %{name}%{postgis_prev_dotless}_%{postgres_version}-devel = %{version}-%{release}
 
 %description devel
 The %{name}-devel package contains the header files and libraries
@@ -82,7 +67,6 @@ with PostGIS.
 
 %package docs
 Summary:	Extra documentation for PostGIS
-Provides:	%{name}%{postgis_prev_dotless}_%{postgres_version}-docs = %{version}-%{release}
 
 %description docs
 The %{name}-docs package includes PDF documentation of PostGIS.
@@ -91,29 +75,30 @@ The %{name}-docs package includes PDF documentation of PostGIS.
 Summary:	The utils for PostGIS
 Requires:	%{name} = %{version}-%{release}
 Requires:	perl-DBD-Pg
-Provides:	%{name}%{postgis_prev_dotless}_%{postgres_version}-utils = %{version}-%{release}
 
 %description utils
 The %{name}-utils package provides the utilities for PostGIS.
 
-%global __perl_requires %{SOURCE4}
+
+# Exclude Post
+%global __perl_requires %{SOURCE2}
 
 
 %prep
 %autosetup -p1 -n %{name}-%{version}%{?prerelease}
 # Copy .pdf file to top directory before installing.
-%{__cp} -p %{SOURCE2} .
+%{__cp} -p %{SOURCE1} .
 
 
 %build
-export LDFLAGS="$LDFLAGS -L%{postgres_instdir}/lib"
 %configure \
-    --enable-rpath --libdir=%{postgres_instdir}/lib \
+    --enable-rpath \
+    --bindir=%{postgres_instdir}/bin \
+    --prefix=%{postgres_instdir} \
     --with-pgconfig=%{postgres_instdir}/bin/pg_config \
     --with-protobuf \
     --with-sfcgal=%{_bindir}/sfcgal-config
-
-%make_build LPATH=`%{postgres_instdir}/bin/pg_config --pkglibdir` shlib="%{name}.so"
+%make_build
 
 
 %install
@@ -126,15 +111,6 @@ export LDFLAGS="$LDFLAGS -L%{postgres_instdir}/lib"
 
 %{__install} -d %{buildroot}%{_docdir}/%{name}-docs-%{version}
 %{__install} -d %{buildroot}%{_docdir}/%{name}-utils-%{version}
-
-# Create symlink of .so files to previous versions. PostGIS hackers said that this is safe:
-%{__ln_s} %{postgres_instdir}/lib/postgis-%{postgisliblabel}.so %{buildroot}%{postgres_instdir}/lib/postgis-%{postgis_prev_majorversion}.so
-%{__ln_s} %{postgres_instdir}/lib/postgis_topology-%{postgisliblabel}.so %{buildroot}%{postgres_instdir}/lib/postgis_topology-%{postgis_prev_majorversion}.so
-%if 0%{postgis_major} >= 3
-%{__ln_s} %{postgres_instdir}/lib/address_standardizer-%{postgisliblabel}.so %{buildroot}%{postgres_instdir}/lib/address_standardizer-%{postgis_prev_majorversion}.so
-%else
-%{__ln_s} %{postgres_instdir}/lib/rtpostgis-%{postgisliblabel}.so %{buildroot}%{postgres_instdir}/lib/rtpostgis-%{postgis_prev_majorversion}.so
-%endif
 
 
 %check
@@ -162,6 +138,8 @@ LANG="C.UTF-8" %{__make} check
 
 # Create alternatives entries for common binaries
 %post
+%{_sbindir}/update-alternatives --install /usr/bin/postgis postgis-postgis %{postgres_instdir}/bin/postgis %{postgres_version}0
+%{_sbindir}/update-alternatives --install /usr/bin/postgis_restore postgis-postgis_restore %{postgres_instdir}/bin/postgis_restore %{postgres_version}0
 %{_sbindir}/update-alternatives --install /usr/bin/pgsql2shp postgis-pgsql2shp %{postgres_instdir}/bin/pgsql2shp %{postgres_version}0
 %{_sbindir}/update-alternatives --install /usr/bin/shp2pgsql postgis-shp2pgsql %{postgres_instdir}/bin/shp2pgsql %{postgres_version}0
 
@@ -171,8 +149,10 @@ LANG="C.UTF-8" %{__make} check
 if [ "$1" -eq 0 ]
   then
         # Only remove these links if the package is completely removed from the system (vs.just being upgraded)
-        %{_sbindir}/update-alternatives --remove postgis-pgsql2shp	%{postgres_instdir}/bin/pgsql2shp
-        %{_sbindir}/update-alternatives --remove postgis-shp2pgsql	%{postgres_instdir}/bin/shp2pgsql
+        %{_sbindir}/update-alternatives --remove postgis-postgis	 %{postgres_instdir}/bin/postgis
+        %{_sbindir}/update-alternatives --remove postgis-postgis_restore %{postgres_instdir}/bin/postgis_restore
+        %{_sbindir}/update-alternatives --remove postgis-pgsql2shp	 %{postgres_instdir}/bin/pgsql2shp
+        %{_sbindir}/update-alternatives --remove postgis-shp2pgsql	 %{postgres_instdir}/bin/shp2pgsql
 fi
 
 
@@ -183,58 +163,29 @@ fi
 %{postgres_instdir}/doc/extension/README.address_standardizer
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/postgis.sql
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/postgis_comments.sql
-%if 0%{postgis_major} < 3
-%{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/postgis_for_extension.sql
-%endif
-%if 0%{postgis_major} == 3
-%if 0%{postgis_minor} < 1
-%{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/postgis_proc_set_search_path.sql
-%endif
-%endif
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/postgis_upgrade*.sql
-%{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/postgis_restore.pl
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/uninstall_postgis.sql
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/legacy*.sql
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/*topology*.sql
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/*sfcgal*.sql
-%{postgres_instdir}/lib/postgis-%{postgis_prev_majorversion}.so
 %attr(0755,root,root) %{postgres_instdir}/lib/postgis-%{postgisliblabel}.so
 %{postgres_instdir}/share/extension/postgis-*.sql
 %{postgres_instdir}/share/extension/postgis_sfcgal*.sql
 %{postgres_instdir}/share/extension/postgis_sfcgal.control
 %{postgres_instdir}/share/extension/postgis.control
-%if 0%{postgis_major} < 3
-%{postgres_instdir}/lib/liblwgeom*.so.*
-%{postgres_instdir}/lib/liblwgeom.so
-%endif
 %{postgres_instdir}/lib/postgis_topology-%{postgisliblabel}.so
-%{postgres_instdir}/lib/postgis_topology-%{postgis_prev_majorversion}.so
-%if 0%{postgis_major} >= 3
 %{postgres_instdir}/lib/address_standardizer-%{postgisliblabel}.so
-%{postgres_instdir}/lib/address_standardizer-%{postgis_prev_majorversion}.so
-%if 0%{postgis_major} == 3
-%if 0%{postgis_minor} >= 1
 %{postgres_instdir}/lib/bitcode/
-%endif
-%endif
-%else
-%{postgres_instdir}/lib/address_standardizer.so
-%endif
 %{postgres_instdir}/share/extension/address_standardizer*.sql
 %{postgres_instdir}/share/extension/address_standardizer*.control
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/raster_comments.sql
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/*rtpostgis*.sql
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/uninstall_legacy.sql
 %{postgres_instdir}/share/contrib/postgis-%{postgis_majorversion}/spatial*.sql
-%if 0%{postgis_major} >= 3
 %{postgres_instdir}/lib/postgis_raster-%{postgisliblabel}.so
 %{postgres_instdir}/lib/postgis_sfcgal-%{postgisliblabel}.so
 %{postgres_instdir}/share/extension/postgis_raster-*.sql
 %{postgres_instdir}/share/extension/postgis_raster.control
-%else
-%{postgres_instdir}/lib/rtpostgis-%{postgisliblabel}.so
-%{postgres_instdir}/lib/rtpostgis-%{postgis_prev_majorversion}.so
-%endif
 %{postgres_instdir}/share/extension/postgis_topology-*.sql
 %{postgres_instdir}/share/extension/postgis_topology.control
 %{postgres_instdir}/share/extension/postgis_tiger_geocoder*.sql
@@ -258,13 +209,16 @@ fi
 %attr(0755,root,root) %{postgres_instdir}/bin/pgsql2shp
 %attr(0755,root,root) %{postgres_instdir}/bin/pgtopo_export
 %attr(0755,root,root) %{postgres_instdir}/bin/pgtopo_import
+%attr(0755,root,root) %{postgres_instdir}/bin/postgis
+%attr(0755,root,root) %{postgres_instdir}/bin/postgis_restore
 %attr(0755,root,root) %{postgres_instdir}/bin/raster2pgsql
 %attr(0755,root,root) %{postgres_instdir}/bin/shp2pgsql
 
 
 %files docs
 %defattr(-,root,root)
-%doc postgis-%{version}%{?prerelease}.pdf
+%doc postgis-%{version}%{?prerelease}-en.pdf
+%{_mandir}
 
 
 %changelog

--- a/SPECS/el9/postgis.spec
+++ b/SPECS/el9/postgis.spec
@@ -80,7 +80,7 @@ Requires:	perl-DBD-Pg
 The %{name}-utils package provides the utilities for PostGIS.
 
 
-# Exclude Post
+# Excludes requiring Perl PostgreSQL module packages.
 %global __perl_requires %{SOURCE2}
 
 

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -29,9 +29,9 @@ x-rpmbuild:
   # and runtime requirements.
   version_limits:
     gdal_min_version: &gdal_min_version 3.7.0
-    geos_min_version: &geos_min_version 3.11.0
+    geos_min_version: &geos_min_version 3.12.0
     libosmium_min_version: &libosmium_min_version 2.18.0
-    postgis_min_version: &postgis_min_version 3.3.0
+    postgis_min_version: &postgis_min_version 3.4.0
     proj_min_version: &proj_min_version 9.2.0
     protobuf-c_min_version: &protobuf_c_min_version 1.3.0
     protobuf_min_version: &protobuf_min_version 3.0.0
@@ -60,13 +60,13 @@ x-rpmbuild:
       version: &caddy_version 2.7.4-1
     gdal:
       image: rpmbuild-gdal
-      version: &gdal_version 3.7.1-1
+      version: &gdal_version 3.7.1-2
       defines:
         geos_min_version: *geos_min_version
         proj_min_version: *proj_min_version
     geos:
       image: rpmbuild-generic
-      version: &geos_version 3.11.2-1
+      version: &geos_version 3.12.0-1
     geoserver:
       arch: noarch
       defines:
@@ -157,7 +157,7 @@ x-rpmbuild:
       version: &passenger_version 6.0.18-1
     postgis:
       image: rpmbuild-postgis
-      version: &postgis_version 3.3.3-1
+      version: &postgis_version 3.4.0-1
       defines:
         gdal_min_version: *gdal_min_version
         geos_min_version: *geos_min_version


### PR DESCRIPTION
* [GEOS 3.12.0](https://github.com/libgeos/geos/releases/tag/3.12.0)
* GDAL 3.7.1-2 to use GEOS 3.12.0, since ABI has changed
* [PostGIS 3.4.0](https://postgis.net/2023/08/PostGIS-3.4.0/), and remove conditionals for older versions.
