### PR TITLE
`planet-dump-ng`

### DIFF
--- a/.github/workflows/ci.el9.yml
+++ b/.github/workflows/ci.el9.yml
@@ -82,6 +82,7 @@ jobs:
           - osmium-tool
           - osmosis
           - passenger
+          - planet-dump-ng
           - postgis
           - proj
           - protozero

--- a/Makefile.el9
+++ b/Makefile.el9
@@ -62,6 +62,7 @@ OSMDBT_RPM := $(call rpm_file,osmdbt)
 OSMIUM_TOOL_RPM := $(call rpm_file,osmium-tool)
 OSMOSIS_RPM := $(call rpm_file,osmosis)
 PASSENGER_RPM := $(call rpm_file,passenger)
+PLANET_DUMP_NG_RPM := $(call rpm_file,planet-dump-ng)
 POSTGIS_RPM := $(call rpm_file,postgis)
 PROJ_RPM := $(call rpm_file,proj)
 PROTOZERO_RPM := $(call rpm_file,protozero)
@@ -104,6 +105,7 @@ RPMBUILD_RPMS := \
 	osmium-tool \
 	osmosis \
 	passenger \
+	planet-dump-ng \
 	postgis \
 	proj \
 	protozero \
@@ -166,6 +168,7 @@ distclean: .env
 	echo RPMBUILD_OSMDBT_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/osmdbt.spec --define postgres_version=$(POSTGRES_VERSION)) >> .env
 	echo RPMBUILD_OSMIUM_TOOL_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/osmium-tool.spec) >> .env
 	echo RPMBUILD_PASSENGER_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/passenger.spec) >> .env
+	echo RPMBUILD_PLANET_DUMP_NG_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/planet-dump-ng.spec) >> .env
 	echo RPMBUILD_POSTGIS_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/postgis.spec --define postgres_version=$(POSTGRES_VERSION)) >> .env
 	echo RPMBUILD_PROJ_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/proj.spec) >> .env
 	echo RPMBUILD_PROTOZERO_PACKAGES=$(shell ./scripts/buildrequires.py SPECS/$(EL_VERSION)/protozero.spec) >> .env
@@ -225,6 +228,7 @@ osmdbt: $(OSMDBT_RPM)
 osmium-tool: $(OSMIUM_TOOL_RPM)
 osmosis: $(OSMOSIS_RPM)
 passenger: $(PASSENGER_RPM)
+planet-dump-ng: $(PLANET_DUMP_NG_RPM)
 postgis: $(POSTGIS_RPM)
 proj: $(PROJ_RPM)
 protozero: $(PROTOZERO_RPM)

--- a/SPECS/el9/planet-dump-ng.spec
+++ b/SPECS/el9/planet-dump-ng.spec
@@ -1,0 +1,54 @@
+# The following macros are also required:
+# * protobuf_min_version
+
+Name:           planet-dump-ng
+Version:        %{rpmbuild_version}
+Release:        %{rpmbuild_release}%{?dist}
+Summary:        Tool for converting an OpenStreetMap database dump into planet files.
+License:        BSD
+URL:            https://github.com/zerebubuth/%{name}
+Source0:        https://github.com/zerebubuth/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  automake
+BuildRequires:  boost-devel
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  libxml2-devel
+BuildRequires:  libosmpbf-devel
+BuildRequires:  protobuf >= %{protobuf_min_version}
+BuildRequires:  protobuf-devel >= %{protobuf_min_version}
+BuildRequires:  protobuf-lite >= %{protobuf_min_version}
+BuildRequires:  protobuf-lite-devel >= %{protobuf_min_version}
+
+
+%description
+Tool for converting an OpenStreetMap database dump into planet files.
+
+By operating on the database dump rather than a running server, this means that running the extraction from PostgreSQL dump file to planetfile(s) is completely independent of the database server, and can be done on a disconnected machine without putting any load on any database.
+
+
+%prep
+%autosetup -p1 -n %{name}-%{version}
+
+
+%build
+# XXX: Patch in current version
+%{__sed} -i -e 's/1\.2\.4/%{version}/g' configure.ac
+./autogen.sh
+%configure
+%make_build
+
+
+%install
+%make_install
+
+
+%files
+%doc README.md
+%license COPYING
+%{_bindir}/planet-dump-ng
+
+
+%changelog
+* %(%{_bindir}/date "+%%a %%b %%d %%Y") %{rpmbuild_name} <%{rpmbuild_email}> - %{version}-%{rpmbuild_release}
+- %{version}-%{rpmbuild_release}

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -161,6 +161,11 @@ x-rpmbuild:
     passenger:
       image: rpmbuild-passenger
       version: &passenger_version 6.0.18-1
+    planet-dump-ng:
+      image: rpmbuild-planet-dump-ng
+      version: &planet_dump_ng_version 1.2.7-1
+      defines:
+        protobuf_min_version: *protobuf_min_version
     postgis:
       image: rpmbuild-postgis
       version: &postgis_version 3.4.0-1
@@ -412,6 +417,14 @@ services:
       args:
         <<: *build_args_defaults
         packages: ${RPMBUILD_PASSENGER_PACKAGES}
+      dockerfile: docker/el9/Dockerfile.rpmbuild-geoint-deps
+  rpmbuild-planet-dump-ng:
+    <<: *service_defaults
+    build:
+      <<: *build_defaults
+      args:
+        <<: *build_args_defaults
+        packages: ${RPMBUILD_PLANET_DUMP_NG_PACKAGES}
       dockerfile: docker/el9/Dockerfile.rpmbuild-geoint-deps
   rpmbuild-postgis:
     <<: *service_defaults


### PR DESCRIPTION
Adds `planet-dump-ng` RPM, via [zerebubuth/planet-dump-ng](https://github.com/zerebubuth/planet-dump-ng); uses `libosmpbf`, refs #175.