### PR TITLE
Docker Compose Plugin

### DIFF
--- a/Makefile.el7
+++ b/Makefile.el7
@@ -1,6 +1,6 @@
 ## Conditional variables.
 DOCKER ?= docker
-DOCKER_COMPOSE ?= docker-compose
+DOCKER_COMPOSE ?= docker compose
 EL_VERSION ?= el7
 CI ?= false
 COMPOSE_FILE ?= docker-compose.$(EL_VERSION).yml
@@ -32,7 +32,7 @@ rpmbuild_version = $(call config_version,$(call rpm_package,$(1)))
 
 ## Variables
 DOCKER_VERSION := $(shell $(DOCKER) --version 2>/dev/null)
-DOCKER_COMPOSE_VERSION := $(shell $(DOCKER_COMPOSE) --version 2>/dev/null)
+DOCKER_COMPOSE_VERSION := $(shell $(DOCKER_COMPOSE) version 2>/dev/null)
 POSTGRES_VERSION := $(call rpmbuild_util,postgres_version,--variable)
 RPMBUILD_CHANNEL := $(call rpmbuild_util,channel_name,--variable)
 RPMBUILD_UID := $(shell id -u)
@@ -146,7 +146,7 @@ ifndef DOCKER_VERSION
 	$(error "command docker is not available, please install Docker")
 endif
 ifndef DOCKER_COMPOSE_VERSION
-	$(error "command docker-compose is not available, please install Docker")
+	$(error "command docker compose is not available, please install the Docker Compose plugin")
 endif
 
 all-rpms: $(RPMBUILD_RPMS)

--- a/Makefile.el9
+++ b/Makefile.el9
@@ -1,6 +1,6 @@
 ## Conditional variables.
 DOCKER ?= docker
-DOCKER_COMPOSE ?= docker-compose
+DOCKER_COMPOSE ?= docker compose
 EL_VERSION ?= el9
 CI ?= false
 COMPOSE_FILE ?= docker-compose.$(EL_VERSION).yml
@@ -32,7 +32,7 @@ rpmbuild_version = $(call config_version,$(call rpm_package,$(1)))
 
 ## Variables
 DOCKER_VERSION := $(shell $(DOCKER) --version 2>/dev/null)
-DOCKER_COMPOSE_VERSION := $(shell $(DOCKER_COMPOSE) --version 2>/dev/null)
+DOCKER_COMPOSE_VERSION := $(shell $(DOCKER_COMPOSE) version 2>/dev/null)
 POSTGRES_VERSION := $(call rpmbuild_util,postgres_version,--variable)
 RPMBUILD_CHANNEL := $(call rpmbuild_util,channel_name,--variable)
 RPMBUILD_UID := $(shell id -u)
@@ -133,7 +133,7 @@ ifndef DOCKER_VERSION
 	$(error "command docker is not available, please install Docker")
 endif
 ifndef DOCKER_COMPOSE_VERSION
-	$(error "command docker-compose is not available, please install Docker")
+	$(error "command docker compose is not available, please install the Docker Compose plugin")
 endif
 
 all-rpms: $(RPMBUILD_RPMS)
@@ -182,11 +182,6 @@ distclean: .env
 
 ## Image targets
 rpmbuild: .env
-	$(call pull_if_ci,$@)
-	$(call build_unless_image_exists,$@)
-
-rpmbuild-fonts: rpmbuild
-	$(call pull_if_ci,$?)
 	$(call pull_if_ci,$@)
 	$(call build_unless_image_exists,$@)
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,9 @@ You will need to have `~/.gnupg-geoint` populated using the `.gpg` file and prov
 ## Requirements
 
 * Linux host and some basics:
-  * Python 3 for `docker-compose` and some of the [scripts](./scripts/).
+  * Python 3 for the [scripts](./scripts/).
   * GNU `make` for [`Makefile.el7`](./Makefile.el7)/[`Makefile.el9`](./Makefile.el9).
 
-* Docker >= 18.09
-  * Recent version recommended to take advantage of [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).
+* Docker
 
-* Docker Compose >= 1.27
-  * Supports compose format 3.7, for its [`init` option](https://docs.docker.com/compose/compose-file/compose-file-v3/#init).
+* [Docker Compose Plugin](https://docs.docker.com/compose/install/linux/)


### PR DESCRIPTION
Use the Docker Compose plugin, e.g., `docker compose` instead of `docker-compose`; test failures are due to a regression with PostGIS 3.4.0 and PostgreSQL 15.5.