### PR TITLE
GEOS 3.12.1 on EL9

### DIFF
--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -66,7 +66,7 @@ x-rpmbuild:
         proj_min_version: *proj_min_version
     geos:
       image: rpmbuild-generic
-      version: &geos_version 3.12.0-1
+      version: &geos_version 3.12.1-1
     geoserver:
       arch: noarch
       defines:


### PR DESCRIPTION
Test failures are unlreated to GEOS upgrade.