### PR TITLE
Verious package updates [EL9]

### DIFF
--- a/SPECS/el9/g2clib.spec
+++ b/SPECS/el9/g2clib.spec
@@ -64,9 +64,11 @@ echo %%g2clib %g2clib > %{buildroot}%{_rpmconfigdir}/macros.d/macros.g2clib
 
 %files devel
 %license LICENSE.md
-%{_libdir}/cmake/%{g2clib}
-%{_libdir}/lib%{g2clib}.so
 %{_includedir}/grib2.h
+%{_libdir}/cmake/%{g2clib}
+%{_libdir}/lib%{g2clib}.a
+%{_libdir}/lib%{g2clib}.so
+%{_libdir}/lib%{g2clib}.so.0
 %{_rpmconfigdir}/macros.d/macros.g2clib
 
 

--- a/SPECS/el9/osm2pgsql.spec
+++ b/SPECS/el9/osm2pgsql.spec
@@ -14,8 +14,8 @@ Release:        %{rpmbuild_release}%{?dist}
 Summary:        Imports map data from OpenStreetMap to a PostgreSQL database
 
 License:        GPLv2+
-URL:            https://github.com/openstreetmap/osm2pgsql
-Source0:        https://github.com/openstreetmap/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+URL:            https://github.com/osm2pgsql-dev/osm2pgsql
+Source0:        https://github.com/osm2pgsql-dev/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 Source1:        https://github.com/nlohmann/json/releases/download/v%{nlohmann_json_version}/json.hpp
 Patch0:         osm2pgsql-replication.patch
 

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -72,7 +72,7 @@ x-rpmbuild:
       defines:
         gdal_version: *gdal_version
       image: rpmbuild-generic
-      version: &geoserver_version 2.23.3-1
+      version: &geoserver_version 2.24.0-1
     geoserver-geonode:
       arch: noarch
       defines:

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -60,7 +60,7 @@ x-rpmbuild:
       version: &caddy_version 2.7.5-1
     gdal:
       image: rpmbuild-gdal
-      version: &gdal_version 3.7.2-1
+      version: &gdal_version 3.8.0-1
       defines:
         geos_min_version: *geos_min_version
         proj_min_version: *proj_min_version
@@ -72,7 +72,7 @@ x-rpmbuild:
       defines:
         gdal_version: *gdal_version
       image: rpmbuild-generic
-      version: &geoserver_version 2.23.1-3
+      version: &geoserver_version 2.23.3-1
     geoserver-geonode:
       arch: noarch
       defines:
@@ -82,7 +82,7 @@ x-rpmbuild:
     g2clib:
       image: rpmbuild-g2clib
       name: g2clib-devel
-      version: &g2clib_version 1.7.0-1
+      version: &g2clib_version 1.8.0-1
     journald-cloudwatch-logs:
       image: rpmbuild-journald-cloudwatch-logs
       version: &journald-cloudwatch-logs_version 0.2.3-1
@@ -151,7 +151,7 @@ x-rpmbuild:
         protozero_min_version: *protozero_min_version
     osm2pgsql:
       image: rpmbuild-osm2pgsql
-      version: &osm2pgsql_version 1.9.2-1
+      version: &osm2pgsql_version 1.10.0-1
       defines:
         libosmium_min_version: *libosmium_min_version
         nlohmann_json_version: 3.11.2
@@ -195,7 +195,7 @@ x-rpmbuild:
         protozero_min_version: *protozero_min_version
     rubygem-libxml-ruby:
       image: rpmbuild-rubygem-libxml-ruby
-      version: &rubygem_libxml_ruby_version 4.1.1-1
+      version: &rubygem_libxml_ruby_version 4.1.2-1
     sbt:
       image: rpmbuild-generic
       version: &sbt_version 1.9.7-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -72,7 +72,7 @@ x-rpmbuild:
       defines:
         gdal_version: *gdal_version
       image: rpmbuild-generic
-      version: &geoserver_version 2.24.0-1
+      version: &geoserver_version 2.23.3-1
     geoserver-geonode:
       arch: noarch
       defines:

--- a/docs/provenance.el9.md
+++ b/docs/provenance.el9.md
@@ -132,9 +132,9 @@ License](http://fonts.jp/hanazono) and the
 
 ## osm2pgsql
 
-The [osm2pgsql](https://github.com/openstreetmap/osm2pgsql) source archives are
+The [osm2pgsql](https://github.com/osm2pgsql-dev/osm2pgsql) source archives are
 obtained directly from GitHub and are
-[GPLv2 licensed](https://github.com/openstreetmap/osm2pgsql/blob/master/COPYING).
+[GPLv2 licensed](https://github.com/osm2pgsql-dev/osm2pgsql/blob/master/COPYING).
 
 The [`osm2pgsql.spec`](../SPECS/el9/osm2pgsql.spec) originates from
 [Fedora's `osm2pgsql` RPM](https://src.fedoraproject.org/rpms/osm2pgsql)


### PR DESCRIPTION
- **GDAL** from `v3.7.2` to `v3.8.0` [https://github.com/OSGeo/gdal/releases]
  - `v3.7.3` has also been released
- **GeoServer** from `v2.23.1` to `v2.24.0` [https://github.com/geoserver/geoserver/releases]
  - `v2.23.3` has also been released
-  **g2clib** from `v1.7.0` to `v1.8.0` [https://github.com/NOAA-EMC/NCEPLIBS-g2c/releases]
- **osm2pgsql** from `v1.9.2` to `v1.10.0` [https://github.com/osm2pgsql-dev/osm2pgsql/releases]
- **rubygem-libxml-ruby** from `v4.1.1` to `v4.1.2` [https://github.com/xml4r/libxml-ruby/tags]