### PR TITLE
Add missing OSM2PGSQL URL updates [EL7]

### DIFF
--- a/SPECS/el7/osm2pgsql.spec
+++ b/SPECS/el7/osm2pgsql.spec
@@ -14,8 +14,8 @@ Release:        %{rpmbuild_release}%{?dist}
 Summary:        Imports map data from OpenStreetMap to a PostgreSQL database
 
 License:        GPLv2+
-URL:            https://github.com/openstreetmap/osm2pgsql
-Source0:        https://github.com/openstreetmap/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+URL:            https://github.com/osm2pgsql-dev/osm2pgsql
+Source0:        https://github.com/osm2pgsql-dev/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 Source1:        https://github.com/nlohmann/json/releases/download/v%{nlohmann_json_version}/json.hpp
 Patch0:         osm2pgsql-replication.patch
 

--- a/docs/provenance.el7.md
+++ b/docs/provenance.el7.md
@@ -182,9 +182,9 @@ Its data package contains archives that are public domain and
 
 ## osm2pgsql
 
-The [osm2pgsql](https://github.com/openstreetmap/osm2pgsql) source archives are
+The [osm2pgsql](https://github.com/osm2pgsql-dev/osm2pgsql) source archives are
 obtained directly from GitHub and are
-[GPLv2 licensed](https://github.com/openstreetmap/osm2pgsql/blob/master/COPYING).
+[GPLv2 licensed](https://github.com/osm2pgsql-dev/osm2pgsql/blob/master/COPYING).
 Using the same license, the following patch files were derived from changesets in GitHub:
 
 * [`osm2pgsql-replication-analyze.patch`](../SOURCES/el7/osm2pgsql-replication-analyze.patch)


### PR DESCRIPTION
OSM2PGSQL's source repository moved from https://github.com/openstreetmap/osm2pgsql to https://github.com/osm2pgsql-dev/osm2pgsql recently.